### PR TITLE
Selectors fix

### DIFF
--- a/Syncano/Parameters/SyncanoParameters.m
+++ b/Syncano/Parameters/SyncanoParameters.m
@@ -52,6 +52,7 @@ NSString *const kSyncanoParametersFilterImage = @"image";
 	if (self) {
 		_timezone = @"UTC";
 
+#ifdef DEBUG
 		NSString *sourceString = [[NSThread callStackSymbols] objectAtIndex:1];
 		NSCharacterSet *separatorSet = [NSCharacterSet characterSetWithCharactersInString:@" -[]+?.,"];
 		NSMutableArray *array = [NSMutableArray arrayWithArray:[sourceString componentsSeparatedByCharactersInSet:separatorSet]];
@@ -87,6 +88,7 @@ NSString *const kSyncanoParametersFilterImage = @"image";
 				[NSException raise:@"Invaild initalization" format:@"Use: %@ for initalization %@ class", allowedSelectors, NSStringFromClass(self.class)];
 			}
 		}
+#endif
 	}
 	return self;
 }


### PR DESCRIPTION
1. Checking should no longer crash production (i.e. release mode); checking for selectors and exceptions are now only when run in debug mode
2. App name should no longer cause problems, the solution of finding selector name string does not depend on app name not containing certain special characters anymore. Still, there could be a problem with app named with a name matching to a full memory address in hex (e.g. 0xff03243d), but who would do _that_?
