### PR TITLE
another portion of changes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,5 +3,5 @@ platform :ios, '7.0'
 source 'https://github.com/CocoaPods/Specs'
 
 pod 'CocoaAsyncSocket', '7.3.3'
-pod 'AFNetworking', '~> 2.2.1'
+pod 'AFNetworking', '~> 2.3.0'
 pod 'Mantle', '~> 1.4.1'

--- a/Syncano.xcodeproj/project.pbxproj
+++ b/Syncano.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		61A1A5561AB767CC0028217F /* NSObject+nullSafe.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A1A5551AB767CC0028217F /* NSObject+nullSafe.m */; };
 		61E36E7B1AB8F62900729FC7 /* SyncanoError.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E36E781AB8F62900729FC7 /* SyncanoError.m */; };
 		61E36E7C1AB8F62900729FC7 /* SyncanoException.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E36E7A1AB8F62900729FC7 /* SyncanoException.m */; };
+		61E36E801AB9C0F100729FC7 /* Config.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 61A1A5521AB74B9E0028217F /* Config.plist */; };
 		97F8EC4AE2134AED9C970E62 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CFEF72E1379411185D85EDA /* libPods.a */; };
 		BEE157CA18D2F33900FFCB6B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 152D0729186863B00020A116 /* Foundation.framework */; };
 		BEE157ED18D2F57A00FFCB6B /* Syncano.m in Sources */ = {isa = PBXBuildFile; fileRef = 152D07521868641F0020A116 /* Syncano.m */; };
@@ -53,6 +54,7 @@
 			dstPath = "include/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				61E36E801AB9C0F100729FC7 /* Config.plist in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Syncano.xcodeproj/project.pbxproj
+++ b/Syncano.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		619E429A1A9E7AA500787585 /* SyncanoArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 619E42991A9E7AA500787585 /* SyncanoArray.m */; };
 		61A1A5501AB74A030028217F /* APIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A1A54F1AB74A030028217F /* APIClient.m */; };
 		61A1A5561AB767CC0028217F /* NSObject+nullSafe.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A1A5551AB767CC0028217F /* NSObject+nullSafe.m */; };
+		61E36E7B1AB8F62900729FC7 /* SyncanoError.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E36E781AB8F62900729FC7 /* SyncanoError.m */; };
+		61E36E7C1AB8F62900729FC7 /* SyncanoException.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E36E7A1AB8F62900729FC7 /* SyncanoException.m */; };
 		97F8EC4AE2134AED9C970E62 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 4CFEF72E1379411185D85EDA /* libPods.a */; };
 		BEE157CA18D2F33900FFCB6B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 152D0729186863B00020A116 /* Foundation.framework */; };
 		BEE157ED18D2F57A00FFCB6B /* Syncano.m in Sources */ = {isa = PBXBuildFile; fileRef = 152D07521868641F0020A116 /* Syncano.m */; };
@@ -80,6 +82,10 @@
 		61A1A5531AB759420028217F /* SyncanoObjectProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyncanoObjectProtocol.h; path = Syncano/SyncanoObjectProtocol.h; sourceTree = SOURCE_ROOT; };
 		61A1A5541AB767CC0028217F /* NSObject+nullSafe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+nullSafe.h"; path = "Syncano/NSObject+nullSafe.h"; sourceTree = SOURCE_ROOT; };
 		61A1A5551AB767CC0028217F /* NSObject+nullSafe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+nullSafe.m"; path = "Syncano/NSObject+nullSafe.m"; sourceTree = SOURCE_ROOT; };
+		61E36E771AB8F62900729FC7 /* SyncanoError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyncanoError.h; path = Syncano/SyncanoError.h; sourceTree = SOURCE_ROOT; };
+		61E36E781AB8F62900729FC7 /* SyncanoError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SyncanoError.m; path = Syncano/SyncanoError.m; sourceTree = SOURCE_ROOT; };
+		61E36E791AB8F62900729FC7 /* SyncanoException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyncanoException.h; path = Syncano/SyncanoException.h; sourceTree = SOURCE_ROOT; };
+		61E36E7A1AB8F62900729FC7 /* SyncanoException.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SyncanoException.m; path = Syncano/SyncanoException.m; sourceTree = SOURCE_ROOT; };
 		BE98F69718D6F59C001EC84E /* server.der */ = {isa = PBXFileReference; lastKnownFileType = file; name = server.der; path = Resources/server.der; sourceTree = "<group>"; };
 		BEE157C918D2F33900FFCB6B /* libsyncano-ios-library.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libsyncano-ios-library.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEE157CD18D2F33900FFCB6B /* syncano-ios-library-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "syncano-ios-library-Prefix.pch"; sourceTree = "<group>"; };
@@ -164,6 +170,10 @@
 				619E42991A9E7AA500787585 /* SyncanoArray.m */,
 				619E42951A9E14C300787585 /* SyncanoParameters.h */,
 				619E42961A9E14C300787585 /* SyncanoParameters.m */,
+				61E36E771AB8F62900729FC7 /* SyncanoError.h */,
+				61E36E781AB8F62900729FC7 /* SyncanoError.m */,
+				61E36E791AB8F62900729FC7 /* SyncanoException.h */,
+				61E36E7A1AB8F62900729FC7 /* SyncanoException.m */,
 				619E428C1A9CB40800787585 /* Helpers */,
 				BEE157CC18D2F33900FFCB6B /* Supporting Files */,
 			);
@@ -294,9 +304,11 @@
 				BEE157ED18D2F57A00FFCB6B /* Syncano.m in Sources */,
 				61A1A5561AB767CC0028217F /* NSObject+nullSafe.m in Sources */,
 				61A1A5501AB74A030028217F /* APIClient.m in Sources */,
+				61E36E7C1AB8F62900729FC7 /* SyncanoException.m in Sources */,
 				619E42971A9E14C300787585 /* SyncanoParameters.m in Sources */,
 				619E429A1A9E7AA500787585 /* SyncanoArray.m in Sources */,
 				619E42941A9E11C600787585 /* SyncanoObject.m in Sources */,
+				61E36E7B1AB8F62900729FC7 /* SyncanoError.m in Sources */,
 				1548BFD819AB5A3000267128 /* SyncanoReachability.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Syncano.xcodeproj/project.pbxproj
+++ b/Syncano.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		619E429A1A9E7AA500787585 /* SyncanoArray.m in Sources */ = {isa = PBXBuildFile; fileRef = 619E42991A9E7AA500787585 /* SyncanoArray.m */; };
 		61A1A5501AB74A030028217F /* APIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A1A54F1AB74A030028217F /* APIClient.m */; };
 		61A1A5561AB767CC0028217F /* NSObject+nullSafe.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A1A5551AB767CC0028217F /* NSObject+nullSafe.m */; };
+		61B4B6D71AC1A74300B4D265 /* NSDictionary+syncanoParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B4B6D61AC1A74300B4D265 /* NSDictionary+syncanoParameters.m */; };
 		61E36E7B1AB8F62900729FC7 /* SyncanoError.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E36E781AB8F62900729FC7 /* SyncanoError.m */; };
 		61E36E7C1AB8F62900729FC7 /* SyncanoException.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E36E7A1AB8F62900729FC7 /* SyncanoException.m */; };
 		61E36E801AB9C0F100729FC7 /* Config.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 61A1A5521AB74B9E0028217F /* Config.plist */; };
@@ -84,6 +85,8 @@
 		61A1A5531AB759420028217F /* SyncanoObjectProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyncanoObjectProtocol.h; path = Syncano/SyncanoObjectProtocol.h; sourceTree = SOURCE_ROOT; };
 		61A1A5541AB767CC0028217F /* NSObject+nullSafe.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSObject+nullSafe.h"; path = "Syncano/NSObject+nullSafe.h"; sourceTree = SOURCE_ROOT; };
 		61A1A5551AB767CC0028217F /* NSObject+nullSafe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+nullSafe.m"; path = "Syncano/NSObject+nullSafe.m"; sourceTree = SOURCE_ROOT; };
+		61B4B6D51AC1A74300B4D265 /* NSDictionary+syncanoParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+syncanoParameters.h"; path = "Syncano/NSDictionary+syncanoParameters.h"; sourceTree = SOURCE_ROOT; };
+		61B4B6D61AC1A74300B4D265 /* NSDictionary+syncanoParameters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+syncanoParameters.m"; path = "Syncano/NSDictionary+syncanoParameters.m"; sourceTree = SOURCE_ROOT; };
 		61E36E771AB8F62900729FC7 /* SyncanoError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyncanoError.h; path = Syncano/SyncanoError.h; sourceTree = SOURCE_ROOT; };
 		61E36E781AB8F62900729FC7 /* SyncanoError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SyncanoError.m; path = Syncano/SyncanoError.m; sourceTree = SOURCE_ROOT; };
 		61E36E791AB8F62900729FC7 /* SyncanoException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyncanoException.h; path = Syncano/SyncanoException.h; sourceTree = SOURCE_ROOT; };
@@ -147,6 +150,8 @@
 				61A1A54F1AB74A030028217F /* APIClient.m */,
 				61A1A5541AB767CC0028217F /* NSObject+nullSafe.h */,
 				61A1A5551AB767CC0028217F /* NSObject+nullSafe.m */,
+				61B4B6D51AC1A74300B4D265 /* NSDictionary+syncanoParameters.h */,
+				61B4B6D61AC1A74300B4D265 /* NSDictionary+syncanoParameters.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -309,6 +314,7 @@
 				61E36E7C1AB8F62900729FC7 /* SyncanoException.m in Sources */,
 				619E42971A9E14C300787585 /* SyncanoParameters.m in Sources */,
 				619E429A1A9E7AA500787585 /* SyncanoArray.m in Sources */,
+				61B4B6D71AC1A74300B4D265 /* NSDictionary+syncanoParameters.m in Sources */,
 				619E42941A9E11C600787585 /* SyncanoObject.m in Sources */,
 				61E36E7B1AB8F62900729FC7 /* SyncanoError.m in Sources */,
 				1548BFD819AB5A3000267128 /* SyncanoReachability.m in Sources */,

--- a/Syncano.xcodeproj/project.pbxproj
+++ b/Syncano.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		61A1A5501AB74A030028217F /* APIClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A1A54F1AB74A030028217F /* APIClient.m */; };
 		61A1A5561AB767CC0028217F /* NSObject+nullSafe.m in Sources */ = {isa = PBXBuildFile; fileRef = 61A1A5551AB767CC0028217F /* NSObject+nullSafe.m */; };
 		61B4B6D71AC1A74300B4D265 /* NSDictionary+syncanoParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B4B6D61AC1A74300B4D265 /* NSDictionary+syncanoParameters.m */; };
+		61B4B6DD1AC1E4C000B4D265 /* NSMutableDictionary+syncanoParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 61B4B6DC1AC1E4BF00B4D265 /* NSMutableDictionary+syncanoParameters.m */; };
 		61E36E7B1AB8F62900729FC7 /* SyncanoError.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E36E781AB8F62900729FC7 /* SyncanoError.m */; };
 		61E36E7C1AB8F62900729FC7 /* SyncanoException.m in Sources */ = {isa = PBXBuildFile; fileRef = 61E36E7A1AB8F62900729FC7 /* SyncanoException.m */; };
 		61E36E801AB9C0F100729FC7 /* Config.plist in CopyFiles */ = {isa = PBXBuildFile; fileRef = 61A1A5521AB74B9E0028217F /* Config.plist */; };
@@ -87,6 +88,8 @@
 		61A1A5551AB767CC0028217F /* NSObject+nullSafe.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSObject+nullSafe.m"; path = "Syncano/NSObject+nullSafe.m"; sourceTree = SOURCE_ROOT; };
 		61B4B6D51AC1A74300B4D265 /* NSDictionary+syncanoParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSDictionary+syncanoParameters.h"; path = "Syncano/NSDictionary+syncanoParameters.h"; sourceTree = SOURCE_ROOT; };
 		61B4B6D61AC1A74300B4D265 /* NSDictionary+syncanoParameters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSDictionary+syncanoParameters.m"; path = "Syncano/NSDictionary+syncanoParameters.m"; sourceTree = SOURCE_ROOT; };
+		61B4B6DB1AC1E4BF00B4D265 /* NSMutableDictionary+syncanoParameters.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSMutableDictionary+syncanoParameters.h"; path = "Syncano/NSMutableDictionary+syncanoParameters.h"; sourceTree = SOURCE_ROOT; };
+		61B4B6DC1AC1E4BF00B4D265 /* NSMutableDictionary+syncanoParameters.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "NSMutableDictionary+syncanoParameters.m"; path = "Syncano/NSMutableDictionary+syncanoParameters.m"; sourceTree = SOURCE_ROOT; };
 		61E36E771AB8F62900729FC7 /* SyncanoError.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyncanoError.h; path = Syncano/SyncanoError.h; sourceTree = SOURCE_ROOT; };
 		61E36E781AB8F62900729FC7 /* SyncanoError.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SyncanoError.m; path = Syncano/SyncanoError.m; sourceTree = SOURCE_ROOT; };
 		61E36E791AB8F62900729FC7 /* SyncanoException.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SyncanoException.h; path = Syncano/SyncanoException.h; sourceTree = SOURCE_ROOT; };
@@ -152,6 +155,8 @@
 				61A1A5551AB767CC0028217F /* NSObject+nullSafe.m */,
 				61B4B6D51AC1A74300B4D265 /* NSDictionary+syncanoParameters.h */,
 				61B4B6D61AC1A74300B4D265 /* NSDictionary+syncanoParameters.m */,
+				61B4B6DB1AC1E4BF00B4D265 /* NSMutableDictionary+syncanoParameters.h */,
+				61B4B6DC1AC1E4BF00B4D265 /* NSMutableDictionary+syncanoParameters.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -317,6 +322,7 @@
 				61B4B6D71AC1A74300B4D265 /* NSDictionary+syncanoParameters.m in Sources */,
 				619E42941A9E11C600787585 /* SyncanoObject.m in Sources */,
 				61E36E7B1AB8F62900729FC7 /* SyncanoError.m in Sources */,
+				61B4B6DD1AC1E4C000B4D265 /* NSMutableDictionary+syncanoParameters.m in Sources */,
 				1548BFD819AB5A3000267128 /* SyncanoReachability.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Syncano/APIClient.m
+++ b/Syncano/APIClient.m
@@ -10,7 +10,7 @@
 
 @implementation APIClient
 
-static NSString *const kSyncanoBaseURL = @"https://syncanotest1-env.elasticbeanstalk.com:443/v1/";
+static NSString *const kSyncanoBaseURL = @"https://syncanotest1-env.elasticbeanstalk.com:443/";
 
 + (instancetype)sharedClient {
 	static APIClient *_sharedClient = nil;
@@ -20,7 +20,8 @@ static NSString *const kSyncanoBaseURL = @"https://syncanotest1-env.elasticbeans
 		_sharedClient.securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
     _sharedClient.securityPolicy.allowInvalidCertificates = YES; // TODO
 		_sharedClient.requestSerializer = [AFJSONRequestSerializer serializerWithWritingOptions:NSJSONWritingPrettyPrinted];
-		_sharedClient.responseSerializer = /*_sharedClient.jsonOutput ? [AFJSONResponseSerializer serializer] : */[AFHTTPResponseSerializer serializer];
+    _sharedClient->_jsonOutput = YES;
+		_sharedClient.responseSerializer = (AFHTTPResponseSerializer <AFURLResponseSerialization> *)(_sharedClient.jsonOutput ? [AFJSONResponseSerializer serializer] : [AFJSONRequestSerializer serializer]);
 	});
 	return _sharedClient;
 }

--- a/Syncano/APIClient.m
+++ b/Syncano/APIClient.m
@@ -15,7 +15,7 @@
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
 		NSDictionary *config = [NSDictionary dictionaryWithContentsOfURL:[NSURL fileURLWithPath:[[NSBundle mainBundle] pathForResource:@"Config" ofType:@"plist"]]];
-		_sharedClient = [[APIClient alloc] initWithBaseURL:[NSURL URLWithString:config[@"BaseURL"]]];
+		_sharedClient = [[self alloc] initWithBaseURL:[NSURL URLWithString:config[@"BaseURL"]]];
 		_sharedClient.securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
 		_sharedClient.requestSerializer = [AFJSONRequestSerializer serializerWithWritingOptions:NSJSONWritingPrettyPrinted];
 		_sharedClient.responseSerializer = _sharedClient.jsonOutput ? [AFJSONResponseSerializer serializer] : [AFHTTPResponseSerializer serializer];

--- a/Syncano/APIClient.m
+++ b/Syncano/APIClient.m
@@ -10,15 +10,17 @@
 
 @implementation APIClient
 
+static NSString *const kSyncanoBaseURL = @"https://syncanotest1-env.elasticbeanstalk.com:443/v1/";
+
 + (instancetype)sharedClient {
 	static APIClient *_sharedClient = nil;
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
-		NSDictionary *config = [NSDictionary dictionaryWithContentsOfURL:[NSURL fileURLWithPath:[[NSBundle mainBundle] pathForResource:@"Config" ofType:@"plist"]]];
-		_sharedClient = [[self alloc] initWithBaseURL:[NSURL URLWithString:config[@"BaseURL"]]];
+		_sharedClient = [[self alloc] initWithBaseURL:[NSURL URLWithString:kSyncanoBaseURL]];
 		_sharedClient.securityPolicy = [AFSecurityPolicy policyWithPinningMode:AFSSLPinningModeNone];
+    _sharedClient.securityPolicy.allowInvalidCertificates = YES; // TODO
 		_sharedClient.requestSerializer = [AFJSONRequestSerializer serializerWithWritingOptions:NSJSONWritingPrettyPrinted];
-		_sharedClient.responseSerializer = _sharedClient.jsonOutput ? [AFJSONResponseSerializer serializer] : [AFHTTPResponseSerializer serializer];
+		_sharedClient.responseSerializer = /*_sharedClient.jsonOutput ? [AFJSONResponseSerializer serializer] : */[AFHTTPResponseSerializer serializer];
 	});
 	return _sharedClient;
 }

--- a/Syncano/NSDictionary+syncanoParameters.h
+++ b/Syncano/NSDictionary+syncanoParameters.h
@@ -10,6 +10,8 @@
 
 @interface NSDictionary (syncanoParameters)
 
-+ (NSDictionary *)syncanoParametersWithID:(NSString *)dbID;
+@property (nonatomic, copy, readonly) NSNumber *dbID;
+
++ (NSDictionary *)syncanoParametersWithID:(NSNumber *)dbID;
 
 @end

--- a/Syncano/NSDictionary+syncanoParameters.h
+++ b/Syncano/NSDictionary+syncanoParameters.h
@@ -1,0 +1,15 @@
+//
+//  NSDictionary+syncanoParameters.h
+//  Syncano
+//
+//  Created by Mateusz on 24.03.2015.
+//  Copyright (c) 2015 Syncano. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSDictionary (syncanoParameters)
+
++ (NSDictionary *)syncanoParametersWithID:(NSString *)dbID;
+
+@end

--- a/Syncano/NSDictionary+syncanoParameters.m
+++ b/Syncano/NSDictionary+syncanoParameters.m
@@ -1,0 +1,18 @@
+//
+//  NSDictionary+syncanoParameters.m
+//  Syncano
+//
+//  Created by Mateusz on 24.03.2015.
+//  Copyright (c) 2015 Syncano. All rights reserved.
+//
+
+#import "NSDictionary+syncanoParameters.h"
+#import "SyncanoObject.h"
+
+@implementation NSDictionary (syncanoParameters)
+
++ (NSDictionary *)syncanoParametersWithID:(NSString *)dbID {
+  return [NSDictionary dictionaryWithObject:dbID forKey:kPropertyDBID];
+}
+
+@end

--- a/Syncano/NSMutableDictionary+syncanoParameters.h
+++ b/Syncano/NSMutableDictionary+syncanoParameters.h
@@ -1,0 +1,15 @@
+//
+//  NSMutableDictionary+syncanoParameters.h
+//  Syncano
+//
+//  Created by Mateusz on 24.03.2015.
+//  Copyright (c) 2015 Syncano. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSMutableDictionary (syncanoParameters)
+
+@property (nonatomic, copy) NSNumber *dbID;
+
+@end

--- a/Syncano/NSMutableDictionary+syncanoParameters.m
+++ b/Syncano/NSMutableDictionary+syncanoParameters.m
@@ -1,22 +1,25 @@
 //
-//  NSDictionary+syncanoParameters.m
+//  NSMutableDictionary+syncanoParameters.m
 //  Syncano
 //
 //  Created by Mateusz on 24.03.2015.
 //  Copyright (c) 2015 Syncano. All rights reserved.
 //
 
-#import "NSDictionary+syncanoParameters.h"
+#import "NSMutableDictionary+syncanoParameters.h"
 #import "SyncanoObject.h"
 
 @implementation NSMutableDictionary (syncanoParameters)
 
-+ (NSDictionary *)syncanoParametersWithID:(NSNumber *)dbID {
-  return [NSDictionary dictionaryWithObject:dbID forKey:kPropertyDBID];
-}
-
 - (NSNumber *)dbID {
   return self[kPropertyDBID];
+}
+
+- (void)setDbID:(NSNumber *)dbID {
+  if (!dbID)
+    [self removeObjectForKey:kPropertyDBID];
+  else
+    [self setObject:dbID forKey:kPropertyDBID];
 }
 
 @end

--- a/Syncano/NSObject+nullSafe.h
+++ b/Syncano/NSObject+nullSafe.h
@@ -12,6 +12,6 @@
 
 @interface NSObject (SyncanoNullSafe)
 
-- (id)nullSafe;
+- (id)syncanoNullSafe;
 
 @end

--- a/Syncano/NSObject+nullSafe.h
+++ b/Syncano/NSObject+nullSafe.h
@@ -1,6 +1,6 @@
 //
 //  NSObject+nullSafe.h
-//  LoaderSplitView
+//  Syncano
 //
 //  Created by Mateusz on 22.01.2015.
 //  Copyright (c) 2015 Syncano. All rights reserved.
@@ -10,7 +10,7 @@
 
 #define ASSIGN_IF_NOT_NIL(leftOperand, rightOperand) { if (rightOperand) leftOperand = rightOperand; }
 
-@interface NSObject (nullSafe)
+@interface NSObject (SyncanoNullSafe)
 
 - (id)nullSafe;
 

--- a/Syncano/NSObject+nullSafe.m
+++ b/Syncano/NSObject+nullSafe.m
@@ -1,6 +1,6 @@
 //
 //  NSObject+nullSafe.m
-//  LoaderSplitView
+//  Syncano
 //
 //  Created by Mateusz on 22.01.2015.
 //  Copyright (c) 2015 Syncano. All rights reserved.
@@ -8,7 +8,7 @@
 
 #import "NSObject+nullSafe.h"
 
-@implementation NSObject (nullSafe)
+@implementation NSObject (SyncanoNullSafe)
 
 - (id)nullSafe {
   return [self isKindOfClass:[NSNull class]] ? nil : self;

--- a/Syncano/NSObject+nullSafe.m
+++ b/Syncano/NSObject+nullSafe.m
@@ -10,7 +10,7 @@
 
 @implementation NSObject (SyncanoNullSafe)
 
-- (id)nullSafe {
+- (id)syncanoNullSafe {
   return [self isKindOfClass:[NSNull class]] ? nil : self;
 }
 

--- a/Syncano/Syncano.h
+++ b/Syncano/Syncano.h
@@ -17,6 +17,8 @@ typedef void(^SyncanoObjectBlock)(NSURLSessionDataTask *task, id<SyncanoObject> 
 typedef void(^SyncanoArrayBlock)(NSURLSessionDataTask *task, SyncanoArray *array);
 typedef void(^SyncanoErrorBlock)(NSURLSessionDataTask *task, NSError *error);
 
+#define SP(dict) [SyncanoParameters parametersWithDictionary:dict]
+
 @interface Syncano : NSObject
 
 @property (strong, readonly, nonatomic) SyncanoReachability *reachability;
@@ -29,7 +31,8 @@ typedef void(^SyncanoErrorBlock)(NSURLSessionDataTask *task, NSError *error);
 - (instancetype)initWithName:(NSString *)name;
 
 // managing objects
-- (NSURLSessionDataTask *)get:(Class)class params:(SyncanoParameters *)params success:(SyncanoObjectBlock)success failure:(SyncanoErrorBlock)failure;
-- (NSURLSessionDataTask *)getArrayOf:(Class)class params:(SyncanoParameters *)params success:(SyncanoArrayBlock)success failure:(SyncanoErrorBlock)failure;
+- (NSURLSessionDataTask *)get:(Class)class params:(NSDictionary *)params success:(SyncanoObjectBlock)success failure:(SyncanoErrorBlock)failure;
+- (NSURLSessionDataTask *)create:(Class)class params:(NSDictionary *)params success:(SyncanoObjectBlock)success failure:(SyncanoErrorBlock)failure;
+- (NSURLSessionDataTask *)getArrayOf:(Class)class params:(NSDictionary *)params success:(SyncanoArrayBlock)success failure:(SyncanoErrorBlock)failure;
 
 @end

--- a/Syncano/Syncano.h
+++ b/Syncano/Syncano.h
@@ -10,10 +10,10 @@
 #import "SyncanoReachability.h"
 #import "SyncanoObjectProtocol.h"
 #import "SyncanoParameters.h"
-#import "SyncanoArray.m"
+#import "SyncanoArray.h"
 
 extern NSInteger const kSyncanoDefaultPageSize;
-typedef void(^SyncanoObjectBlock)(NSURLSessionDataTask *task, id<SyncanoObjectProtocol> object);
+typedef void(^SyncanoObjectBlock)(NSURLSessionDataTask *task, id<SyncanoObject> object);
 typedef void(^SyncanoArrayBlock)(NSURLSessionDataTask *task, SyncanoArray *array);
 typedef void(^SyncanoErrorBlock)(NSURLSessionDataTask *task, NSError *error);
 

--- a/Syncano/Syncano.m
+++ b/Syncano/Syncano.m
@@ -1,3 +1,4 @@
+
 //
 //  Syncano.m
 //  Syncano
@@ -9,11 +10,21 @@
 #import "Syncano.h"
 #import "APIClient.h"
 #import <AFNetworking/AFNetworking.h>
+#import <Mantle.h>
+#import "SyncanoError.h"
+#import "SyncanoException.h"
 
 NSInteger const kSyncanoDefaultPageSize = 100;
 
+NSString *const kAPIKey = @"apiKey";
+NSString *const kDefaultName = @"defaultName";
+
+NSString *const kPropertyDBID = @"dbID";
+
+NSString *const kSyncanoURLObjects = @"instances/%@/classes/%@/objects/%@";
+
 @interface Syncano () {
-	NSString *_apiKey;
+  NSString *_apiKey;
 }
 @end
 
@@ -25,103 +36,111 @@ NSInteger const kSyncanoDefaultPageSize = 100;
 static Syncano *_sharedInstance = nil;
 
 + (NSDictionary *)settings {
-	static NSDictionary *_settings = nil;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		_settings = [NSDictionary dictionaryWithContentsOfURL:[NSURL fileURLWithPath:[[NSBundle mainBundle] pathForResource:@"Syncano" ofType:@"plist"]]];
-	});
-	return _settings;
+  static NSDictionary *_settings = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSString *filePath = [[NSBundle mainBundle] pathForResource:@"Syncano" ofType:@"plist"];
+    if (filePath)
+      _settings = [NSDictionary dictionaryWithContentsOfURL:[NSURL fileURLWithPath:filePath]];
+  });
+  return _settings;
 }
 
 + (instancetype)sharedInstanceWithAPIKey:(NSString *)apiKey name:(NSString *)name {
-	static dispatch_once_t onceToken;
-	
-	__block NSString *defaultAPIKey = apiKey;
-	__block NSString *defaultName = name;
-	dispatch_once(&onceToken, ^{
-		if (![defaultAPIKey length])
-			defaultAPIKey = [Syncano settings][@"apiKey"];
-		if (![defaultName length])
-			defaultName = [Syncano settings][@"defaultName"];
-		
-		if ([defaultAPIKey length] && [defaultName length]) {
-			_sharedInstance = [[Syncano alloc] initWithAPIKey:defaultAPIKey name:defaultName];
-		}
-	});
-	
-	return _sharedInstance;
+  static dispatch_once_t onceToken;
+  
+  __block NSString *defaultAPIKey = apiKey;
+  __block NSString *defaultName = name;
+  dispatch_once(&onceToken, ^{
+    if (![defaultAPIKey length])
+      defaultAPIKey = [Syncano settings][kAPIKey];
+    if (![defaultName length])
+      defaultName = [Syncano settings][kDefaultName];
+    
+    if ([defaultAPIKey length] && [defaultName length]) {
+      _sharedInstance = [[Syncano alloc] initWithAPIKey:defaultAPIKey name:defaultName];
+    }
+  });
+  
+  return _sharedInstance;
 }
 
 + (instancetype)sharedInstance {
-	return [Syncano sharedInstanceWithAPIKey:[Syncano settings][@"apiKey"] name:[Syncano settings][@"defaultName"]];
+  return [Syncano sharedInstanceWithAPIKey:[Syncano settings][kAPIKey] name:[Syncano settings][kDefaultName]];
 }
 
 + (instancetype)setSharedInstanceName:(NSString *)name {
-	Syncano *instance = [Syncano sharedInstance];
-	if (!instance)
-		return [Syncano sharedInstanceWithAPIKey:[Syncano settings][@"apiKey"] name:name];
-
-	instance->_name = [name copy];
-	return instance;
+  Syncano *instance = [Syncano sharedInstance];
+  if (!instance)
+    return [Syncano sharedInstanceWithAPIKey:[Syncano settings][kAPIKey] name:name];
+  
+  instance->_name = [name copy];
+  return instance;
 }
 
 - (instancetype)initWithName:(NSString *)name {
-	return [self initWithAPIKey:[Syncano settings][@"apiKey"] name:name];
+  return [self initWithAPIKey:[Syncano settings][kAPIKey] name:name];
 }
 
 - (instancetype)initWithAPIKey:(NSString *)apiKey name:(NSString *)name {
-	if (![apiKey length] || ![name length])
-		return nil;
-	
-	self = [super init];
-	if (self) {
-		_apiKey = [apiKey copy];
-		_name = [name copy];
-	}
-	return self;
+  if (![apiKey length] || ![name length])
+    return nil;
+  
+  self = [super init];
+  if (self) {
+    _apiKey = [apiKey copy];
+    _name = [name copy];
+  }
+  return self;
 }
 
 + (instancetype)syncanoWithName:(NSString *)name {
-	return [Syncano syncanoWithAPIKey:[Syncano settings][@"apiKey"] name:name];
+  return [Syncano syncanoWithAPIKey:[Syncano settings][kAPIKey] name:name];
 }
 
 + (instancetype)syncanoWithAPIKey:(NSString *)apiKey name:(NSString *)name {
-	return [[Syncano alloc] initWithAPIKey:apiKey name:name];
+  return [[Syncano alloc] initWithAPIKey:apiKey name:name];
 }
 
 - (void)dealloc {
-	_apiKey = nil;
-	_name = nil;
+  _apiKey = nil;
+  _name = nil;
 }
 
 - (NSURLSessionDataTask *)get:(Class)class params:(SyncanoParameters *)params success:(SyncanoObjectBlock)success failure:(SyncanoErrorBlock)failure {
-	if (![class conformsToProtocol:@protocol(SyncanoObjectProtocol)]) {
-		[NSException exceptionWithName:@"Syncano.InvalidParameterException" reason:[NSString stringWithFormat:@"%@ does not conform to protocol SyncanoObjectProtocol", NSStringFromClass(class)] userInfo:nil];
-		return nil;
-	}
-	
-	NSString *url = [NSString stringWithFormat:@"instances/%@/classes/%@/objects/%@", self.name, NSStringFromClass(class), params[@"dbID"]];
-	return [[APIClient sharedClient] POST:url
-														 parameters:params
-																success:^(NSURLSessionDataTask *task, id responseObject) {
-																	if (success) {
-																		NSDictionary *json = responseObject;
-																		if ([json isKindOfClass:[NSDictionary class]]) {
-																			id<SyncanoObjectProtocol> object = [class alloc];
-																			success(task, [object initWithJSON:json]);
-																		}
-																		else if (failure)
-																			failure(task, [NSError errorWithDomain:@"Syncano" code:100 userInfo:nil]);
-																	}
-																}
-																failure:^(NSURLSessionDataTask *task, NSError *error) {
-																	if (failure)
-																		failure(task, error);
-																}];
+  if (![class conformsToProtocol:@protocol(SyncanoObject)]) {
+    [[SyncanoException exceptionWithCode:SyncanoExceptionInvalidParameter reason:[NSString stringWithFormat:@"%@ does not conform to protocol %@", NSStringFromClass(class), NSStringFromProtocol(@protocol(SyncanoObject))]] raise];
+    return nil;
+  }
+  
+  NSString *url = [NSString stringWithFormat:kSyncanoURLObjects, self.name, NSStringFromClass(class), params[kPropertyDBID]];
+  return [[APIClient sharedClient] POST:url
+                             parameters:params
+                                success:^(NSURLSessionDataTask *task, id responseObject) {
+                                  if (success) {
+                                    NSDictionary *json = responseObject;
+                                    if ([json isKindOfClass:[NSDictionary class]]) {
+                                      NSError *error = nil;
+                                      id<SyncanoObject> object = [MTLJSONAdapter modelOfClass:[class alloc] fromJSONDictionary:json error:&error];
+                                      if (error) {
+                                        if (failure)
+                                          failure(task, error);
+                                      }
+                                      else
+                                        success(task, [object initWithJSON:json]);
+                                    }
+                                    else if (failure)
+                                      failure(task, [SyncanoError errorWithCode:SyncanoErrorResponseIsNotJSONDictionary]);
+                                  }
+                                }
+                                failure:^(NSURLSessionDataTask *task, NSError *error) {
+                                  if (failure)
+                                    failure(task, error);
+                                }];
 }
 
 - (NSURLSessionDataTask *)getArrayOf:(Class)class params:(SyncanoParameters *)params success:(SyncanoArrayBlock)success failure:(SyncanoErrorBlock)failure {
-	return nil;
+  return nil;
 }
 
 @end

--- a/Syncano/Syncano.m
+++ b/Syncano/Syncano.m
@@ -24,8 +24,9 @@ NSString *const kPropertyDBID = @"dbID";
 NSString *const kSyncanoURLObjects = @"instances/%@/classes/%@/objects/%@";
 
 @interface Syncano () {
-  NSString *_apiKey;
 }
+@property (nonatomic, copy) NSString *apiKey;
+@property (nonatomic, copy) NSString *name;
 @end
 
 
@@ -74,7 +75,7 @@ static Syncano *_sharedInstance = nil;
   if (!instance)
     return [Syncano sharedInstanceWithAPIKey:[Syncano settings][kAPIKey] name:name];
   
-  instance->_name = [name copy];
+  instance.name = name;
   return instance;
 }
 
@@ -88,8 +89,8 @@ static Syncano *_sharedInstance = nil;
   
   self = [super init];
   if (self) {
-    _apiKey = [apiKey copy];
-    _name = [name copy];
+    self.apiKey = apiKey;
+    self.name = name;
   }
   return self;
 }
@@ -103,8 +104,6 @@ static Syncano *_sharedInstance = nil;
 }
 
 - (void)dealloc {
-  _apiKey = nil;
-  _name = nil;
 }
 
 - (NSURLSessionDataTask *)get:(Class)class params:(SyncanoParameters *)params success:(SyncanoObjectBlock)success failure:(SyncanoErrorBlock)failure {

--- a/Syncano/SyncanoError.h
+++ b/Syncano/SyncanoError.h
@@ -8,10 +8,10 @@
 
 #import <Foundation/Foundation.h>
 
-typedef enum {
+typedef NS_ENUM(NSInteger, SyncanoErrorCode) {
   SyncanoErrorInvalidParameter = 0,
   SyncanoErrorResponseIsNotJSONDictionary
-} SyncanoErrorCode;
+};
 
 @interface SyncanoError : NSError
 

--- a/Syncano/SyncanoError.h
+++ b/Syncano/SyncanoError.h
@@ -1,0 +1,21 @@
+//
+//  SyncanoError.h
+//  Syncano
+//
+//  Created by Mateusz on 17.03.2015.
+//  Copyright (c) 2015 Syncano. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+typedef enum {
+  SyncanoErrorInvalidParameter = 0,
+  SyncanoErrorResponseIsNotJSONDictionary
+} SyncanoErrorCode;
+
+@interface SyncanoError : NSError
+
++ (id)errorWithCode:(SyncanoErrorCode)code;
++ (id)errorWithCode:(SyncanoErrorCode)code userInfo:(NSDictionary *)dictionary;
+
+@end

--- a/Syncano/SyncanoError.m
+++ b/Syncano/SyncanoError.m
@@ -1,0 +1,21 @@
+//
+//  SyncanoError.m
+//  Syncano
+//
+//  Created by Mateusz on 17.03.2015.
+//  Copyright (c) 2015 Syncano. All rights reserved.
+//
+
+#import "SyncanoError.h"
+
+@implementation SyncanoError
+
++ (id)errorWithCode:(SyncanoErrorCode)code {
+  return [[self class] errorWithCode:code userInfo:nil];
+}
+
++ (id)errorWithCode:(SyncanoErrorCode)code userInfo:(NSDictionary *)dictionary {
+  return [[self class] errorWithDomain:@"Syncano" code:code userInfo:dictionary];
+}
+
+@end

--- a/Syncano/SyncanoException.h
+++ b/Syncano/SyncanoException.h
@@ -10,9 +10,9 @@
 
 extern NSString *const kSyncanoExceptionInvalidParameter;
 
-typedef enum {
+typedef NS_ENUM(NSInteger, SyncanoExceptionCode) {
   SyncanoExceptionInvalidParameter = 0
-} SyncanoExceptionCode;
+};
 
 @interface SyncanoException : NSException
 

--- a/Syncano/SyncanoException.h
+++ b/Syncano/SyncanoException.h
@@ -1,0 +1,22 @@
+//
+//  SyncanoException.h
+//  Syncano
+//
+//  Created by Mateusz on 17.03.2015.
+//  Copyright (c) 2015 Syncano. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+extern NSString *const kSyncanoExceptionInvalidParameter;
+
+typedef enum {
+  SyncanoExceptionInvalidParameter = 0
+} SyncanoExceptionCode;
+
+@interface SyncanoException : NSException
+
++ (instancetype)exceptionWithCode:(SyncanoExceptionCode)code;
++ (instancetype)exceptionWithCode:(SyncanoExceptionCode)code reason:(NSString *)reason;
+
+@end

--- a/Syncano/SyncanoException.m
+++ b/Syncano/SyncanoException.m
@@ -1,0 +1,42 @@
+//
+//  SyncanoException.m
+//  Syncano
+//
+//  Created by Mateusz on 17.03.2015.
+//  Copyright (c) 2015 Syncano. All rights reserved.
+//
+
+#import "SyncanoException.h"
+
+@implementation SyncanoException
+
+NSString *const kSyncanoExceptionInvalidParameter = @"Syncano.InvalidParameterException";
+
++ (instancetype)exceptionWithCode:(SyncanoExceptionCode)code {
+  NSString *reason = nil;
+  
+  switch (code) {
+    default:
+      break;
+  }
+  
+  return [[self class] exceptionWithCode:code reason:reason];
+}
+
++ (instancetype)exceptionWithCode:(SyncanoExceptionCode)code reason:(NSString *)reason {
+  NSString *name = nil;
+  NSDictionary *userInfo = nil;
+  
+  switch (code) {
+    case SyncanoExceptionInvalidParameter:
+      name = kSyncanoExceptionInvalidParameter;
+      break;
+      
+    default:
+      break;
+  }
+  
+  return [[[self class] alloc] initWithName:name reason:reason userInfo:userInfo];
+}
+
+@end

--- a/Syncano/SyncanoException.m
+++ b/Syncano/SyncanoException.m
@@ -36,7 +36,7 @@ NSString *const kSyncanoExceptionInvalidParameter = @"Syncano.InvalidParameterEx
       break;
   }
   
-  return [[[self class] alloc] initWithName:name reason:reason userInfo:userInfo];
+  return [[self alloc] initWithName:name reason:reason userInfo:userInfo];
 }
 
 @end

--- a/Syncano/SyncanoObject.h
+++ b/Syncano/SyncanoObject.h
@@ -17,13 +17,11 @@ extern NSString *const kPropertyDBID;
 	NSDate *_updatedAt;
 	NSInteger _revision;
 	NSInteger _dbID;
-	NSString *_sidekick;
 }
 
 @property (copy, readonly) NSDate *createdAt;
 @property (copy, readonly) NSDate *updatedAt;
 @property (assign, readonly) NSInteger revision;
 @property (assign, readonly) NSInteger dbID;
-@property (copy, readonly) NSString *sidekick;
 
 @end

--- a/Syncano/SyncanoObject.h
+++ b/Syncano/SyncanoObject.h
@@ -8,8 +8,9 @@
 
 #import <Foundation/Foundation.h>
 #import "SyncanoObjectProtocol.h"
+#import <Mantle/Mantle.h>
 
-@interface SyncanoObject : NSObject <SyncanoObjectProtocol> {
+@interface SyncanoObject : MTLModel <SyncanoObject> {
 	NSDate *_createdAt;
 	NSDate *_updatedAt;
 	NSInteger _revision;
@@ -17,8 +18,8 @@
 	NSString *_sidekick;
 }
 
-@property (strong, readonly) NSDate *createdAt;
-@property (strong, readonly) NSDate *updatedAt;
+@property (copy, readonly) NSDate *createdAt;
+@property (copy, readonly) NSDate *updatedAt;
 @property (assign, readonly) NSInteger revision;
 @property (assign, readonly) NSInteger dbID;
 @property (copy, readonly) NSString *sidekick;

--- a/Syncano/SyncanoObject.h
+++ b/Syncano/SyncanoObject.h
@@ -10,6 +10,8 @@
 #import "SyncanoObjectProtocol.h"
 #import <Mantle/Mantle.h>
 
+extern NSString *const kPropertyDBID;
+
 @interface SyncanoObject : MTLModel <SyncanoObject> {
 	NSDate *_createdAt;
 	NSDate *_updatedAt;

--- a/Syncano/SyncanoObject.h
+++ b/Syncano/SyncanoObject.h
@@ -11,17 +11,38 @@
 #import <Mantle/Mantle.h>
 
 extern NSString *const kPropertyDBID;
+extern NSString *const kPropertyCreatedAt;
+extern NSString *const kPropertyUpdatedAt;
+extern NSString *const kPropertyRevision;
+extern NSString *const kPropertyLinks;
+extern NSString *const kPropertyGroup;
+extern NSString *const kPropertyGroupPermissions;
+extern NSString *const kPropertyOwner;
+extern NSString *const kPropertyOwnerPermissions;
+extern NSString *const kPropertyOtherPermissions;
 
 @interface SyncanoObject : MTLModel <SyncanoObject> {
 	NSDate *_createdAt;
 	NSDate *_updatedAt;
 	NSInteger _revision;
 	NSInteger _dbID;
+  NSDictionary *_links;
+  NSString *_group;
+  NSInteger _groupPermissions;
+  NSString *_owner;
+  NSInteger _ownerPermissions;
+  NSInteger _otherPermissions;
 }
 
 @property (copy, readonly) NSDate *createdAt;
 @property (copy, readonly) NSDate *updatedAt;
 @property (assign, readonly) NSInteger revision;
 @property (assign, readonly) NSInteger dbID;
+@property (retain, readonly) NSDictionary *links;
+@property (copy, readonly) NSString *group;
+@property (assign, readonly) NSInteger groupPermissions;
+@property (copy, readonly) NSString *owner;
+@property (assign, readonly) NSInteger ownerPermissions;
+@property (assign, readonly) NSInteger otherPermissions;
 
 @end

--- a/Syncano/SyncanoObject.m
+++ b/Syncano/SyncanoObject.m
@@ -10,13 +10,31 @@
 
 @implementation SyncanoObject
 
+NSString *const kPropertyDBID = @"dbID";
+NSString *const kPropertyCreatedAt = @"createdAt";
+NSString *const kPropertyUpdatedAt = @"updatedAt";
+NSString *const kPropertyRevision = @"revision";
+NSString *const kPropertyLinks = @"links";
+NSString *const kPropertyGroup = @"group";
+NSString *const kPropertyGroupPermissions = @"groupPermissions";
+NSString *const kPropertyOwner = @"owner";
+NSString *const kPropertyOwnerPermissions = @"ownerPermissions";
+NSString *const kPropertyOtherPermissions = @"otherPermissions";
+
 #pragma mark - MTLJSONSerializing
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
-  return @{@"createdAt":@"created_at",
-           @"updatedAt":@"updated_at",
-           @"revision":@"revision",
-           @"dbID":@"id"};
+  return @{kPropertyCreatedAt:@"created_at",
+           kPropertyUpdatedAt:@"updated_at",
+           kPropertyRevision:@"revision",
+           kPropertyDBID:@"id",
+           kPropertyLinks:@"links",
+           kPropertyGroup:@"group",
+           kPropertyGroupPermissions:@"group_permissions",
+           kPropertyOwner:@"owner",
+           kPropertyOwnerPermissions:@"owner_permissions",
+           kPropertyOtherPermissions:@"other_permissions",
+           };
 }
 
 @end

--- a/Syncano/SyncanoObject.m
+++ b/Syncano/SyncanoObject.m
@@ -13,11 +13,10 @@
 #pragma mark - MTLJSONSerializing
 
 + (NSDictionary *)JSONKeyPathsByPropertyKey {
-  return @{@"createdAt":@"createdAt",
-           @"updatedAt":@"updatedAt",
+  return @{@"createdAt":@"created_at",
+           @"updatedAt":@"updated_at",
            @"revision":@"revision",
-           @"dbID":@"id",
-           @"sidekick":@"sidekick"};
+           @"dbID":@"id"};
 }
 
 @end

--- a/Syncano/SyncanoObject.m
+++ b/Syncano/SyncanoObject.m
@@ -7,30 +7,17 @@
 //
 
 #import "SyncanoObject.h"
-#import "NSObject+nullSafe.h"
 
 @implementation SyncanoObject
 
-+ (instancetype)objectWithJSON:(NSDictionary *)json {
-	return [[[self class] alloc] initWithJSON:json];
-}
-
-- (id)initWithJSON:(NSDictionary *)json {
-	self = [super init];
-	if (self) {
-		ASSIGN_IF_NOT_NIL(_createdAt, [json[@"createdAt"] nullSafe]);
-		ASSIGN_IF_NOT_NIL(_updatedAt, [json[@"updatedAt"] nullSafe]);
-		ASSIGN_IF_NOT_NIL(_revision, [[json[@"revision"] nullSafe] integerValue]);
-		ASSIGN_IF_NOT_NIL(_dbID, [[json[@"dbID"] nullSafe] integerValue]);
-		ASSIGN_IF_NOT_NIL(_sidekick, [json[@"sidekick"] nullSafe]);
-	}
-	return self;
-}
-
 #pragma mark - MTLJSONSerializing
 
-- (NSString *)JSONKeyPathForPropertyKey:(NSString *)key {
-  return key; // by default Syncano fields and object properties are presumed to match
++ (NSDictionary *)JSONKeyPathsByPropertyKey {
+  return @{@"createdAt":@"createdAt",
+           @"updatedAt":@"updatedAt",
+           @"revision":@"revision",
+           @"dbID":@"id",
+           @"sidekick":@"sidekick"};
 }
 
 @end

--- a/Syncano/SyncanoObject.m
+++ b/Syncano/SyncanoObject.m
@@ -27,4 +27,10 @@
 	return self;
 }
 
+#pragma mark - MTLJSONSerializing
+
+- (NSString *)JSONKeyPathForPropertyKey:(NSString *)key {
+  return key; // by default Syncano fields and object properties are presumed to match
+}
+
 @end

--- a/Syncano/SyncanoObjectProtocol.h
+++ b/Syncano/SyncanoObjectProtocol.h
@@ -7,17 +7,18 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <Mantle/Mantle.h>
 
-@protocol SyncanoObjectProtocol <NSObject>
+@protocol SyncanoObject <MTLJSONSerializing>
 
 @required
 + (instancetype)objectWithJSON:(NSDictionary *)json;
 - (id)initWithJSON:(NSDictionary *)json;
 
-- (NSDate *)createdAt;
-- (NSDate *)updatedAt;
-- (NSInteger)revision;
-- (NSInteger)dbID;
-- (NSString *)sidekick;
+@property (copy, readonly) NSDate *createdAt;
+@property (copy, readonly) NSDate *updatedAt;
+@property (assign, readonly) NSInteger revision;
+@property (assign, readonly) NSInteger dbID;
+@property (copy, readonly) NSString *sidekick;
 
 @end

--- a/Syncano/SyncanoObjectProtocol.h
+++ b/Syncano/SyncanoObjectProtocol.h
@@ -17,6 +17,5 @@
 @property (copy, readonly) NSDate *updatedAt;
 @property (assign, readonly) NSInteger revision;
 @property (assign, readonly) NSInteger dbID;
-@property (copy, readonly) NSString *sidekick;
 
 @end

--- a/Syncano/SyncanoObjectProtocol.h
+++ b/Syncano/SyncanoObjectProtocol.h
@@ -12,8 +12,6 @@
 @protocol SyncanoObject <MTLJSONSerializing>
 
 @required
-+ (instancetype)objectWithJSON:(NSDictionary *)json;
-- (id)initWithJSON:(NSDictionary *)json;
 
 @property (copy, readonly) NSDate *createdAt;
 @property (copy, readonly) NSDate *updatedAt;

--- a/Syncano/SyncanoObjectProtocol.h
+++ b/Syncano/SyncanoObjectProtocol.h
@@ -17,5 +17,11 @@
 @property (copy, readonly) NSDate *updatedAt;
 @property (assign, readonly) NSInteger revision;
 @property (assign, readonly) NSInteger dbID;
+@property (retain, readonly) NSDictionary *links;
+@property (copy, readonly) NSString *group;
+@property (assign, readonly) NSInteger groupPermissions;
+@property (copy, readonly) NSString *owner;
+@property (assign, readonly) NSInteger ownerPermissions;
+@property (assign, readonly) NSInteger otherPermissions;
 
 @end

--- a/Syncano/SyncanoParameters.h
+++ b/Syncano/SyncanoParameters.h
@@ -8,6 +8,11 @@
 
 #import <Foundation/Foundation.h>
 
-@interface SyncanoParameters : NSMutableDictionary
+@interface SyncanoParameters : NSObject <NSCopying, NSCoding>
+
+@property (nonatomic, retain, readonly) NSDictionary *dictionary;
+
++ (instancetype)parametersWithDictionary:(NSDictionary *)dict;
+- (instancetype)initWithDictionary:(NSDictionary *)dict;
 
 @end

--- a/Syncano/SyncanoParameters.m
+++ b/Syncano/SyncanoParameters.m
@@ -8,6 +8,36 @@
 
 #import "SyncanoParameters.h"
 
+@interface SyncanoParameters ()
+@property (nonatomic, retain) NSDictionary *dictionary;
+@end
+
 @implementation SyncanoParameters
+
+NSString *const kPropertyDictionary = @"kPropertyDictionary";
+
++ (instancetype)parametersWithDictionary:(NSDictionary *)dict {
+  return [[self alloc] initWithDictionary:dict];
+}
+
+- (instancetype)initWithDictionary:(NSDictionary *)dict {
+  self = [super init];
+  if (self)
+    self.dictionary = dict;
+  return self;
+}
+
+#pragma mark - NSCoding
+
+- (void)encodeWithCoder:(NSCoder *)aCoder {
+  [aCoder encodeObject:self.dictionary forKey:kPropertyDictionary];
+}
+
+- (id)initWithCoder:(NSCoder *)aDecoder {
+  NSDictionary *dict = [aDecoder decodeObjectForKey:kPropertyDictionary];
+  if (![dict isKindOfClass:[NSDictionary class]])
+    dict = nil;
+  return [self initWithDictionary:dict];
+}
 
 @end


### PR DESCRIPTION
changed APIClient to call [self class] instead of [APIClient class]
changed nullSafe to SyncanoNullSafe category name for NSObject
corrected #include to #import "SyncanoArray.h"
added proper keys to Syncano.m to avoid pure strings
added check for the existence of Syncano.plist in custom project
used Mantle to deserialize JSON to objects
introduced SyncanoError and SyncanoException
changed protocol name from SyncanoObjectProtocol to SyncanoObject
changed getter methods of SyncanoObject protocol into properties