### PR TITLE
Add setNilValueForKey

### DIFF
--- a/syncano-ios/SCDataObject.m
+++ b/syncano-ios/SCDataObject.m
@@ -150,6 +150,17 @@
     [self updateValue:value forKey:key usingAPIClient:syncano.apiClient withCompletion:completion];
 }
 
+
+/**
+ * In API it's possible to have attributes without any values. In this case, when parsing JSON
+ * we will try to set a nil value for certain key. This works well in Obj-C but causes a crash
+ * when Swift Class properties are not of optional type
+ *
+ * Implementing this method lets Swift app avoid crashing
+ */
+- (void)setNilValueForKey:(NSString *)key {
+}
+
 - (void)updateValue:(id)value forKey:(NSString *)key usingAPIClient:(SCAPIClient *)apiClient withCompletion:(SCCompletionBlock)completion {
     NSError *validationError;
     SCValidateAndSetValue(self, key, value, YES, &validationError);


### PR DESCRIPTION
In API it's possible to have attributes without any values. In this
case, when parsing JSON, we will try to set a nil value for certain
key. This works well in Obj-C but causes a crash when Swift Class
properties are not of optional type

Implementing this method lets Swift app avoid crashing