### PR TITLE
Create SCDataObject from dictionary

### DIFF
--- a/syncano-ios/SCDataObject.h
+++ b/syncano-ios/SCDataObject.h
@@ -67,8 +67,7 @@
 + (void)registerClass;
 
 /**
- *  Returns SCDataObject instance created by parsing key/value
- *  pairs in provided dictionary.
+ *  Returns SCDataObject instance created by parsing dictionary passed as a parameter
  *
  *  @param dictionary Dictionary with properties used to initialize new object
  *

--- a/syncano-ios/SCDataObject.h
+++ b/syncano-ios/SCDataObject.h
@@ -67,6 +67,16 @@
 + (void)registerClass;
 
 /**
+ *  Returns SCDataObject instance created by parsing key/value
+ *  pairs in provided dictionary.
+ *
+ *  @param dictionary Dictionary with properties used to initialize new object
+ *
+ *  @return SCDataObject (or a subclass) created from provided dictionary
+ */
++ (instancetype)objectFromDictionary:(NSDictionary *)dictionary;
+
+/**
  *  Saves object to API in background for singleton default Syncano instance
  *
  *  @param completion completion block

--- a/syncano-ios/SCDataObject.m
+++ b/syncano-ios/SCDataObject.m
@@ -57,6 +57,10 @@
     return [SCPlease pleaseInstanceForDataObjectWithClass:[self class] forSyncano:syncano];
 }
 
++ (instancetype)objectFromDictionary:(NSDictionary *)dictionary {
+    return [[SCParseManager sharedSCParseManager] parsedObjectOfClass:self fromJSONObject:dictionary];
+}
+
 - (NSString *)pathForObject {
     if (self.links[@"self"]) {
         return self.links[@"self"];


### PR DESCRIPTION
Allows creating SCDataObject using dictionary. Uses SCParseManager
behind the scenes and hides it from the user.

Helpful when working with channels - when new objects are created,
channel notification contains payload dictionary, which is an object.
This method allows easy object creation using received payload.