### PR TITLE
Fix object save if error

### DIFF
--- a/syncano-ios/SCDataObject.m
+++ b/syncano-ios/SCDataObject.m
@@ -114,6 +114,10 @@
                 }
             } else {
                 [apiClient postTaskWithPath:[self path] params:params  completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
+                    if (completion && error) {
+                        completion(error);
+                        return;
+                    }
                     [self updateObjectAfterSaveWithDataFromJSONObject:responseObject];
                     [self saveFilesUsingAPIClient:apiClient completion:^(NSError *error) {
                         if (completion) {


### PR DESCRIPTION
We should pass error forward - right now it was overwritten with empty
error from saving file.