### PR TITLE
[LIB-490] Fix ability to save files

### DIFF
--- a/syncano-ios.podspec
+++ b/syncano-ios.podspec
@@ -21,5 +21,6 @@ Pod::Spec.new do |s|
   s.dependency 'AFNetworking', '2.6.3'
   s.dependency 'Mantle', '~> 2.0'
   s.dependency 'UICKeyChainStore', '~> 2.0'
+  s.dependency 'FMDB', '2.6'
 
 end

--- a/syncano-ios/SCDataObject.m
+++ b/syncano-ios/SCDataObject.m
@@ -195,27 +195,12 @@
     }];
 }
 
-- (NSDictionary *)filesForPropertyNamesThatNeedToBeUploaded {
-    NSMutableDictionary *filesForPropertyNamesThatNeedToBeUploaded = [NSMutableDictionary dictionary];
-    NSArray *filesProperties = [[self class] propertiesNamesOfFileClass];
-    for (NSString *filePropertyName in filesProperties) {
-        SCFile * file = (SCFile *)[self valueForKey:filePropertyName];
-        if (file.needsToBeUploaded) {
-            filesForPropertyNamesThatNeedToBeUploaded[filePropertyName] = file;
-        }
-    }
-    return filesForPropertyNamesThatNeedToBeUploaded;
-}
-
-- (id)responseObjectWithFileValuesThatNeedToBeUploaded:(id)responseObject {
-    NSMutableDictionary *responseCopy = [responseObject mutableCopy];
-    [responseCopy setValuesForKeysWithDictionary:[self filesForPropertyNamesThatNeedToBeUploaded]];
-    return responseCopy;
-}
-
 - (void)updateObjectAfterSaveWithDataFromJSONObject:(id)responseObject {
-    id responseObjectWithFileValuesThatNeedToBeUploaded = [self responseObjectWithFileValuesThatNeedToBeUploaded:responseObject];
-    [[SCParseManager sharedSCParseManager] fillObject:self withDataFromJSONObject:responseObjectWithFileValuesThatNeedToBeUploaded];
+    self.objectId = responseObject[@"id"];
+    self.links = responseObject[@"links"];
+    self.revision = responseObject[@"revision"];
+    self.created_at = [[SCConstants SCDataObjectDatesTransformer] transformedValue:responseObject[@"created_at"]];
+    self.updated_at = [[SCConstants SCDataObjectDatesTransformer] transformedValue:responseObject[@"updated_at"]];
 }
 
 - (void)saveFilesUsingAPIClient:(SCAPIClient *)apiClient completion:(SCCompletionBlock)completion {

--- a/syncano-ios/SCFile.h
+++ b/syncano-ios/SCFile.h
@@ -1,6 +1,6 @@
 //
 //  SCFile.h
-//  syncano4-ios
+//  syncano-ios
 //
 //  Created by Jan Lipmann on 26/06/15.
 //  Copyright (c) 2015 Syncano. All rights reserved.
@@ -28,6 +28,11 @@
  *  After set this property to YES fetched data will be stored and can be accessed via 'data' property
  */
 @property (nonatomic) BOOL storeDataAfterFetch;
+
+/**
+ * Informs if file will be sent to Syncano when saving object containig it. Read-only
+ */
+@property (nonatomic, readonly) BOOL needsToBeUploaded;
 
 /**
  *  SCFile initializer

--- a/syncano-ios/SCFile.m
+++ b/syncano-ios/SCFile.m
@@ -1,6 +1,6 @@
 //
 //  SCFile.m
-//  syncano4-ios
+//  syncano-ios
 //
 //  Created by Jan Lipmann on 26/06/15.
 //  Copyright (c) 2015 Syncano. All rights reserved.
@@ -13,7 +13,7 @@
 #import "Syncano.h"
 
 @interface SCFile ()
-@property (nonatomic) BOOL needsToBeUploaded;
+@property (nonatomic,readwrite) BOOL needsToBeUploaded;
 @property (readwrite) NSData *data;
 @end
 

--- a/syncano-ios/SCParseManager+SCDataObject.m
+++ b/syncano-ios/SCParseManager+SCDataObject.m
@@ -59,7 +59,7 @@
 
 - (void)resolveFilesForObject:(id)parsedObject withJSONObject:(id)JSONObject {
     for (NSString *key in [JSONObject allKeys]) {
-        if ([parsedObject respondsToSelector:@selector(key)]) {
+        if ([parsedObject respondsToSelector:NSSelectorFromString(key)]) {
             id object = JSONObject[key];
             if ([object isKindOfClass:[NSDictionary class]] && object[@"type"] && [object[@"type"] isEqualToString:@"file"]) {
                 //TODO change to send error


### PR DESCRIPTION
Instead of blindly refreshing whole object right before saving files
(and by that - removing these files before they were saved) we now
modify response object to contain files that need to be uploaded.

Also made needsToBeUploaded public. I tried using valueForKey and SEL but it felt dirty, and could easily break with potential property name change.

Added FMDB as a dependency - otherwise it doesn’t install in projects using our library. 