### PR TITLE
[hot-fix] Fetching SCFile

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Syncano's iOS Library (syncano-ios) is available under the MIT license. See the 
 
 ## Change Log
 --
+* **4.0.8** - 2016-02-10
+    * Fixed issue with fetching SCFile content 
 * **4.0.7** - 2016-01-29
     * Fixed default owner permissions when creating a new object
 * **4.0.6** - 2015-12-01

--- a/syncano-ios.podspec
+++ b/syncano-ios.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "syncano-ios"
-  s.version      = "4.0.7"
+  s.version      = "4.0.8"
   s.summary      = "Library for http://syncano.com API"
 
   s.homepage     = "http://www.syncano.com"

--- a/syncano-ios/SCFile.m
+++ b/syncano-ios/SCFile.m
@@ -83,7 +83,7 @@
                 _data = [[NSData alloc] initWithData:responseObject];
             }
             if (completion) {
-                completion(self.data,nil);
+                completion(responseObject,nil);
             }
         }
     }];


### PR DESCRIPTION
Without this fix, it always returns self.data, which is nil by default (unless `storeDataAfterFetch` was set to `YES`)