### PR TITLE
Hotifx 4.0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Syncano's iOS Library (syncano-ios) is available under the MIT license. See the 
 
 ## Change Log
 --
+* **4.0.10** - 2016-02-12
+    * Fixed using custom class for User and User Profile 
 * **4.0.9** - 2016-02-11
     * Offline storage (save results to offline and query local storage)
     * Added string filtering on objects (contains, startsWith, endsWith - both case sensitive and insensitivie)

--- a/syncano-ios.podspec
+++ b/syncano-ios.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "syncano-ios"
-  s.version      = "4.0.9"
+  s.version      = "4.0.10"
   s.summary      = "Library for http://syncano.com API"
 
   s.homepage     = "http://www.syncano.com"

--- a/syncano-ios.xcodeproj/project.pbxproj
+++ b/syncano-ios.xcodeproj/project.pbxproj
@@ -140,6 +140,8 @@
 		11F9AEDC1B62105C00B51341 /* SCCodeBoxSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 11F9AEDB1B62105C00B51341 /* SCCodeBoxSpec.m */; };
 		11F9AEDE1B62113D00B51341 /* Trace.json in Resources */ = {isa = PBXBuildFile; fileRef = 11F9AEDD1B62113D00B51341 /* Trace.json */; };
 		11F9AEE01B62128200B51341 /* SCTraceSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 11F9AEDF1B62128200B51341 /* SCTraceSpec.m */; };
+		15094F3A1C6E9156007CD77D /* SCUser+UserDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = 15094F381C6E9156007CD77D /* SCUser+UserDefaults.h */; };
+		15094F3B1C6E9156007CD77D /* SCUser+UserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 15094F391C6E9156007CD77D /* SCUser+UserDefaults.m */; };
 		1A0C9F9AB10B04BEF302047E /* libPods-syncano-IntegrationTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D8C906C57A3E6F58B7391840 /* libPods-syncano-IntegrationTests.a */; };
 		3A822952B9060FB5C5A84B79 /* libPods-syncano-iosTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 347C0A9448448E4AA515720F /* libPods-syncano-iosTests.a */; };
 		A6274DC41C69E65600730460 /* certfile.der in Resources */ = {isa = PBXBuildFile; fileRef = A6274DC31C69E65600730460 /* certfile.der */; };
@@ -339,6 +341,8 @@
 		11F9AEDB1B62105C00B51341 /* SCCodeBoxSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCCodeBoxSpec.m; sourceTree = "<group>"; };
 		11F9AEDD1B62113D00B51341 /* Trace.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Trace.json; sourceTree = "<group>"; };
 		11F9AEDF1B62128200B51341 /* SCTraceSpec.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SCTraceSpec.m; sourceTree = "<group>"; };
+		15094F381C6E9156007CD77D /* SCUser+UserDefaults.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SCUser+UserDefaults.h"; sourceTree = "<group>"; };
+		15094F391C6E9156007CD77D /* SCUser+UserDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "SCUser+UserDefaults.m"; sourceTree = "<group>"; };
 		347C0A9448448E4AA515720F /* libPods-syncano-iosTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-syncano-iosTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		46752C1A7D469AA33BF9E983 /* Pods-syncano-IntegrationTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-syncano-IntegrationTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-syncano-IntegrationTests/Pods-syncano-IntegrationTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4774A8459614E32C080156A1 /* Pods-Syncano.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Syncano.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Syncano/Pods-Syncano.debug.xcconfig"; sourceTree = "<group>"; };
@@ -431,6 +435,8 @@
 				119A93561AFA4238001ADA7C /* SCUser.m */,
 				119A935B1AFB88A5001ADA7C /* SCUserProfile.h */,
 				119A935C1AFB88A5001ADA7C /* SCUserProfile.m */,
+				15094F381C6E9156007CD77D /* SCUser+UserDefaults.h */,
+				15094F391C6E9156007CD77D /* SCUser+UserDefaults.m */,
 			);
 			name = User;
 			sourceTree = "<group>";
@@ -852,6 +858,7 @@
 				11CE3CBE1BCFDC3000DE3163 /* SCChannelNotificationMessage.h in Headers */,
 				11F8BF831BE1083F00091F58 /* SCDataObject+LocalStorage.h in Headers */,
 				11CE3CBB1BCFDC3000DE3163 /* SCChannelDelegate.h in Headers */,
+				15094F3A1C6E9156007CD77D /* SCUser+UserDefaults.h in Headers */,
 				A6BCC8F51C56526B008A0B0A /* SCPleaseProtected.h in Headers */,
 				11CE3CA41BCFDC3000DE3163 /* SCDataObject.h in Headers */,
 				115E320A1BF33FEA000130DE /* SCRegisterManager.h in Headers */,
@@ -1257,6 +1264,7 @@
 				11CE3CAC1BCFDC3000DE3163 /* SCCompoundPredicate.m in Sources */,
 				1152FF951C04A036001D267C /* SCCompoundPredicate+LocalStorage.m in Sources */,
 				11CE3CC11BCFDC3000DE3163 /* NSObject+SCParseHelper.m in Sources */,
+				15094F3B1C6E9156007CD77D /* SCUser+UserDefaults.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1643,6 +1651,7 @@
 				A6274DE21C69FB3600730460 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/syncano-ios/SCAPIClient.m
+++ b/syncano-ios/SCAPIClient.m
@@ -16,6 +16,7 @@
 #import "SCRequest.h"
 #import "SCUploadRequest.h"
 #import "AFNetworkReachabilityManager.h"
+#import "SCUser+UserDefaults.h"
 
 @interface SCAPIClient () <SCRequestQueueDelegate>
 @property (nonatomic,copy) NSString *apiKey;
@@ -69,8 +70,8 @@
     if(self.instanceName != nil) {
         [hash appendString:self.instanceName];
     }
-    if ([SCUser currentUser]) {
-        [hash appendString:[SCUser currentUser].userKey];
+    if ([SCUser userKeyFromDefaults]) {
+        [hash appendString:[SCUser userKeyFromDefaults]];
     }
     return [hash sc_MD5String];
 }

--- a/syncano-ios/SCUser+UserDefaults.h
+++ b/syncano-ios/SCUser+UserDefaults.h
@@ -1,0 +1,19 @@
+//
+//  SCUser+UserDefaults.h
+//  syncano-ios
+//
+//  Created by Mariusz Wisniewski on 2/12/16.
+//  Copyright © 2016 Syncano. All rights reserved.
+//
+
+#import "SCUser.h"
+
+@interface SCUser (UserDefaults)
+
++ (id)JSONUserDataFromDefaults;
++ (void)saveJSONUserData:(id)JSONUserData;
++ (void)removeUserFromDefaults;
+
++ (NSString *)userKeyFromDefaults;
+
+@end

--- a/syncano-ios/SCUser+UserDefaults.m
+++ b/syncano-ios/SCUser+UserDefaults.m
@@ -1,0 +1,45 @@
+//
+//  SCUser+UserDefaults.m
+//  syncano-ios
+//
+//  Created by Mariusz Wisniewski on 2/12/16.
+//  Copyright © 2016 Syncano. All rights reserved.
+//
+
+#import "SCUser+UserDefaults.h"
+#import "NSObject+SCParseHelper.h"
+
+NSString *const kCurrentUser = @"com.syncano.kCurrentUser";
+
+@implementation SCUser (UserDefaults)
+
++ (id)JSONUserDataFromDefaults {
+    NSData *data = [[NSUserDefaults standardUserDefaults] objectForKey:kCurrentUser];
+    if (data) {
+        id userData = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+        return userData;
+    }
+    return nil;
+}
+
++ (void)saveJSONUserData:(id)JSONUserData {
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:JSONUserData];
+    [[NSUserDefaults standardUserDefaults] setObject:data forKey:kCurrentUser];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
++ (void)removeUserFromDefaults {
+    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCurrentUser];
+    [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
++ (NSString *)userKeyFromDefaults {
+    NSString *userKey = nil;
+    id jsonUserData = [self JSONUserDataFromDefaults];
+    if ([jsonUserData respondsToSelector:@selector(objectForKey:)]) {
+        userKey = [jsonUserData[@"user_key"] sc_stringOrEmpty];
+    }
+    return userKey;
+}
+
+@end

--- a/syncano-ios/SCUser.m
+++ b/syncano-ios/SCUser.m
@@ -13,9 +13,8 @@
 #import "SCParseManager+SCUser.h"
 #import "UICKeyChainStore/UICKeyChainStore.h"
 #import "NSObject+SCParseHelper.h"
+#import "SCUser+UserDefaults.h"
 
-
-static NSString *const kCurrentUser = @"com.syncano.kCurrentUser";
 static id _currentUser;
 
 @implementation SCUser
@@ -42,21 +41,6 @@ static id _currentUser;
         return _currentUser;
     }
     return nil;
-}
-
-+ (id)JSONUserDataFromDefaults {
-    NSData *data = [[NSUserDefaults standardUserDefaults] objectForKey:kCurrentUser];
-    if (data) {
-        id userData = [NSKeyedUnarchiver unarchiveObjectWithData:data];
-        return userData;
-    }
-    return nil;
-}
-
-+ (void)saveJSONUserData:(id)JSONUserData {
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:JSONUserData];
-    [[NSUserDefaults standardUserDefaults] setObject:data forKey:kCurrentUser];
-    [[NSUserDefaults standardUserDefaults] synchronize];
 }
 
 + (void)registerClass {
@@ -136,8 +120,7 @@ static id _currentUser;
 }
 
 - (void)logout {
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:kCurrentUser];
-    [[NSUserDefaults standardUserDefaults] synchronize];
+    [[self class] removeUserFromDefaults];
     UICKeyChainStore *keychain = [UICKeyChainStore keyChainStoreWithService:@"com.syncano"];
     [keychain removeItemForKey:kUserKeyKeychainKey];
     _currentUser = nil;


### PR DESCRIPTION
Fixed using custom profile and custom user class.

Before, `[SCUser currentUser]` was being instantiated before custom classes could have been registered -- because of that `currentUser` was always of class `SCUser` and profile always of class `SCUserProfile` .

@jaskooo @trapi 
I have a problem with tests here, not sure how to write them. 
The issue wasn't discovered in current tests, because we log out user out after each single test (which clears user object saved on disk). 
The issue is only visible when there is a user object on disk. Any suggestions?