### PR TITLE
Create new user without logging him in automatically

### DIFF
--- a/syncano-ios/SCConstants.h
+++ b/syncano-ios/SCConstants.h
@@ -10,12 +10,14 @@
 @class SCTrace;
 @class SCWebhookResponseObject;
 @class SCChannelNotificationMessage;
+@class SCUser;
 
 typedef void (^SCAPICompletionBlock)(NSURLSessionDataTask *task, id responseObject, NSError *error);
 typedef void (^SCAPIFileDownloadCompletionBlock)(id responseObject, NSError *error);
 typedef void (^SCDataObjectsCompletionBlock)(NSArray *objects, NSError *error);
 typedef void (^SCParseObjectCompletionBlock)(id parsedObject, NSError *error);
 typedef void (^SCCompletionBlock)(NSError *error);
+typedef void (^SCUserCompletionBlock)(SCUser *user, NSError *error);
 typedef void (^SCCodeBoxCompletionBlock)(SCTrace *trace,NSError *error);
 typedef void (^SCTraceCompletionBlock)(SCTrace *trace, NSError *error);
 typedef void (^SCWebhookCompletionBlock)(SCWebhookResponseObject *responseObject, NSError *error);

--- a/syncano-ios/SCConstants.h
+++ b/syncano-ios/SCConstants.h
@@ -17,7 +17,7 @@ typedef void (^SCAPIFileDownloadCompletionBlock)(id responseObject, NSError *err
 typedef void (^SCDataObjectsCompletionBlock)(NSArray *objects, NSError *error);
 typedef void (^SCParseObjectCompletionBlock)(id parsedObject, NSError *error);
 typedef void (^SCCompletionBlock)(NSError *error);
-typedef void (^SCUserCompletionBlock)(SCUser *user, NSError *error);
+typedef void (^SCCompletionBlockWithUser)(SCUser *user, NSError *error);
 typedef void (^SCCodeBoxCompletionBlock)(SCTrace *trace,NSError *error);
 typedef void (^SCTraceCompletionBlock)(SCTrace *trace, NSError *error);
 typedef void (^SCWebhookCompletionBlock)(SCWebhookResponseObject *responseObject, NSError *error);

--- a/syncano-ios/SCUser.h
+++ b/syncano-ios/SCUser.h
@@ -32,7 +32,6 @@
 
 + (void)registerClassWithProfileClass:(__unsafe_unretained Class)profileClass;
 
-
 /**
  *  Attempts to login user into singleton Syncano
  *
@@ -92,24 +91,24 @@
 
 /**
  *  Attempts to register user into singleton Syncano,
- *  but does not automatically login that user. It returns the newly created user in the completionBlock
+ *  but does not automatically login that user. It returns the newly created user in the completion block
  *
  *  @param username   username for login
  *  @param password   password for login
  *  @param completion completion block
  */
-+ (void)registerWithUsername:(NSString *)username password:(NSString *)password completionBlockWithNewUser:(SCUserCompletionBlock)completion;
++ (void)registerWithUsername:(NSString *)username password:(NSString *)password completionBlockWithNewUser:(SCCompletionBlockWithUser)completion;
 
 /**
  *  Attempts to register user into provided Syncano instance,
- *  but does not automatically login that user. It returns the newly created user in the completionBlock
+ *  but does not automatically login that user. It returns the newly created user in the completion block
  *
  *  @param username   username for login
  *  @param password   password for login
  *  @param syncano    syncano instance for login in to
  *  @param completion completion block
  */
-+ (void)registerWithUsername:(NSString *)username password:(NSString *)password usingAPIClient:(SCAPIClient *)apiClient completionBlockWithNewUser:(SCUserCompletionBlock)completion {
++ (void)registerWithUsername:(NSString *)username password:(NSString *)password inSyncano:(Syncano *)syncano completionBlockWithNewUser:(SCCompletionBlockWithUser)completion;
     
 /**
  *  Returns SCPlease instance for singleton Syncano

--- a/syncano-ios/SCUser.h
+++ b/syncano-ios/SCUser.h
@@ -91,6 +91,27 @@
 + (void)registerWithUsername:(NSString *)username password:(NSString *)password inSyncano:(Syncano *)syncano completion:(SCCompletionBlock)completion;
 
 /**
+ *  Attempts to register user into singleton Syncano,
+ *  but does not automatically login that user. It returns the newly created user in the completionBlock
+ *
+ *  @param username   username for login
+ *  @param password   password for login
+ *  @param completion completion block
+ */
++ (void)registerWithUsername:(NSString *)username password:(NSString *)password completionBlockWithNewUser:(SCUserCompletionBlock)completion;
+
+/**
+ *  Attempts to register user into provided Syncano instance,
+ *  but does not automatically login that user. It returns the newly created user in the completionBlock
+ *
+ *  @param username   username for login
+ *  @param password   password for login
+ *  @param syncano    syncano instance for login in to
+ *  @param completion completion block
+ */
++ (void)registerWithUsername:(NSString *)username password:(NSString *)password usingAPIClient:(SCAPIClient *)apiClient completionBlockWithNewUser:(SCUserCompletionBlock)completion {
+    
+/**
  *  Returns SCPlease instance for singleton Syncano
  *
  *  @return SCPlease instance

--- a/syncano-ios/SCUser.m
+++ b/syncano-ios/SCUser.m
@@ -113,6 +113,23 @@ static id _currentUser;
     }];
 }
 
++ (void)registerWithUsername:(NSString *)username password:(NSString *)password completionBlockWithNewUser:(SCUserCompletionBlock)completion {
+    [self registerWithUsername:username password:password usingAPIClient:[Syncano sharedAPIClient] completionBlockWithNewUser:completion];
+}
+
++ (void)registerWithUsername:(NSString *)username password:(NSString *)password usingAPIClient:(SCAPIClient *)apiClient completionBlockWithNewUser:(SCUserCompletionBlock)completion {
+    
+    NSDictionary *params = @{@"username" : username , @"password" : password};
+    [apiClient postTaskWithPath:@"users/" params:params completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
+        if (error) {
+            completion(nil, error);
+        } else {
+            SCUser *newUser = [[SCParseManager sharedSCParseManager] parsedUserObjectFromJSONObject:responseObject];
+            completion(newUser, nil);
+        }
+    }];
+}
+
 + (void)loginWithSocialBackend:(SCSocialAuthenticationBackend)backend authToken:(NSString *)authToken completion:(SCCompletionBlock)completion {
     [self loginWithSocialBackend:backend authToken:authToken usingAPIClient:[Syncano sharedAPIClient] completion:completion];
 }

--- a/syncano-ios/SCUser.m
+++ b/syncano-ios/SCUser.m
@@ -113,12 +113,15 @@ static id _currentUser;
     }];
 }
 
-+ (void)registerWithUsername:(NSString *)username password:(NSString *)password completionBlockWithNewUser:(SCUserCompletionBlock)completion {
++ (void)registerWithUsername:(NSString *)username password:(NSString *)password completionBlockWithNewUser:(SCCompletionBlockWithUser)completion {
     [self registerWithUsername:username password:password usingAPIClient:[Syncano sharedAPIClient] completionBlockWithNewUser:completion];
 }
 
-+ (void)registerWithUsername:(NSString *)username password:(NSString *)password usingAPIClient:(SCAPIClient *)apiClient completionBlockWithNewUser:(SCUserCompletionBlock)completion {
-    
++ (void)registerWithUsername:(NSString *)username password:(NSString *)password inSyncano:(Syncano *)syncano completionBlockWithNewUser:(SCCompletionBlockWithUser)completion {
+    [self registerWithUsername:username password:password usingAPIClient:syncano.apiClient completionBlockWithNewUser:completion];
+}
+
++ (void)registerWithUsername:(NSString *)username password:(NSString *)password usingAPIClient:(SCAPIClient *)apiClient completionBlockWithNewUser:(SCCompletionBlockWithUser)completion {
     NSDictionary *params = @{@"username" : username , @"password" : password};
     [apiClient postTaskWithPath:@"users/" params:params completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
         if (error) {


### PR DESCRIPTION
Added a new static method in SCUser to allow registering users without login him automatically. It also returns the newly created user so you can, for exemple, update its profile right away. Useful in cases where an admin of a private system wants to register users, because they can't use the app without being invited.

by @patricktremblay1