### PR TITLE
Saving empty relations fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Syncano's iOS Library (syncano-ios) is available under the MIT license. See the 
 
 ## Change Log
 --
+* **4.0.11** - 2016-02-15
+    * Fixed saving objects with empty relations 
 * **4.0.10** - 2016-02-12
     * Fixed using custom class for User and User Profile 
 * **4.0.9** - 2016-02-11

--- a/syncano-ios.podspec
+++ b/syncano-ios.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "syncano-ios"
-  s.version      = "4.0.10"
+  s.version      = "4.0.11"
   s.summary      = "Library for http://syncano.com API"
 
   s.homepage     = "http://www.syncano.com"

--- a/syncano-ios/SCDataObject.m
+++ b/syncano-ios/SCDataObject.m
@@ -316,6 +316,10 @@
         dispatch_group_t relationSaveGroup = dispatch_group_create();
         for (NSString *propertyName in relations.allKeys) {
             SCDataObject *relatedObject = [self valueForKey:propertyName];
+            // no object here, go to saving next one
+            if (relatedObject == nil) {
+                continue;
+            }
             if ([relatedObject isKindOfClass:[SCDataObject class]]) {
                 if (!relatedObject.objectId) {
                     dispatch_group_enter(relationSaveGroup);

--- a/syncano-ios/SCParseManager+SCDataObject.m
+++ b/syncano-ios/SCParseManager+SCDataObject.m
@@ -96,6 +96,11 @@
         NSMutableDictionary *mutableSerialized = serialized.mutableCopy;
         for (NSString *relationProperty in relations.allKeys) {
             id relatedObject = [dataObject valueForKey:relationProperty];
+            // relatedObject == nil means no relation was set at all
+            // and we want to handle only ones that were set but were not saved
+            if (relatedObject == nil) {
+                continue;
+            }
             NSNumber *objectId = [relatedObject valueForKey:@"objectId"];
             if (objectId) {
                 [mutableSerialized setObject:objectId forKey:relationProperty];


### PR DESCRIPTION
Fixes saving empty relations. Before, when object was equal to `nil`, both
```objc
[relatedObject isKindOfClass:[SCDataObject class]]
```
and
```objc
if (objectId)
```
were returning NO, causing errors and not saving objects properly.