### PR TITLE
[LIB-484] add missing predicates

### DIFF
--- a/SyncanoIntegrationTests/LocalStorageSpec.m
+++ b/SyncanoIntegrationTests/LocalStorageSpec.m
@@ -213,7 +213,6 @@ describe(@"LocalStorageSpec", ^{
             testBook(predicate, YES);
         });
     });
-    
 });
 
 SPEC_END

--- a/SyncanoIntegrationTests/UserLoginSpec.m
+++ b/SyncanoIntegrationTests/UserLoginSpec.m
@@ -48,7 +48,7 @@ describe(@"User login", ^{
         }
     };
     
-    //Below "sharedExamplesFor" from Kiwi should be used but it didn't want to work with xctool :(
+    //Below "sharedExamplesFor" from Kiwi should be used but it didn't work with xctool :(
     
     it(@"should login with Google", ^{
         if(![environment[@"GOOGLE_TOKEN_KEY"] isEqualToString:@"$GOOGLE_TOKEN_KEY"])

--- a/syncano-ios/SCPredicate+LocalStorage.m
+++ b/syncano-ios/SCPredicate+LocalStorage.m
@@ -11,15 +11,27 @@
 @implementation SCPredicate (LocalStorage)
 - (NSPredicate *)nspredicateRepresentation {
     NSExpression *lexp = [NSExpression expressionForKeyPath:[self leftHand]];
-    NSExpression *rexp = [NSExpression expressionForConstantValue:[self rightHand]];
+    NSExpression *rexp = [NSExpression expressionForConstantValue:[self rightHandForNspredicate]];
     NSPredicateOperatorType op = [self nspredicateOperatorRepresentationForOperator:[self operator]];
+    NSComparisonPredicateOptions options = [self nspredicateOptionsForOperator:[self operator]];
     
     NSPredicate *predicate = [NSComparisonPredicate predicateWithLeftExpression:lexp
                                                          rightExpression:rexp
                                                                 modifier:0
                                                                     type:op
-                                                                 options:0];
+                                                                 options:options];
     return predicate;
+}
+
+- (NSString*)rightHandForNspredicate {
+    NSString* operator = [self operator];
+    NSString* rightHand = [self rightHand];
+    
+    if([operator isEqualToString:SCPredicateStringContainsOperator] || [operator isEqualToString:SCPredicateStringiContainsOperator]) {
+        rightHand = [NSString stringWithFormat:@"*%@*",rightHand];
+    }
+        
+    return rightHand;
 }
 
 - (NSPredicateOperatorType)nspredicateOperatorRepresentationForOperator:(NSString *)operator {
@@ -30,8 +42,29 @@
                                 SCPredicateEqualOperator : @(NSEqualToPredicateOperatorType),
                                 SCPredicateNotEqualOperator : @(NSNotEqualToPredicateOperatorType),
                                 SCPredicateExistsOperator : @(NSEqualToPredicateOperatorType),
-                                SCPredicateInOperator : @(NSInPredicateOperatorType)};
+                                SCPredicateInOperator : @(NSInPredicateOperatorType),
+                                SCPredicateStringStartsWithOperator: @(NSBeginsWithPredicateOperatorType),
+                                SCPredicateStringiStartsWithOperator: @(NSBeginsWithPredicateOperatorType),
+                                SCPredicateStringEndsWithOperator: @(NSEndsWithPredicateOperatorType),
+                                SCPredicateStringiEndsWithOperator: @(NSEndsWithPredicateOperatorType),
+                                SCPredicateStringiEqualOperator : @(NSEqualToPredicateOperatorType),
+                                SCPredicateStringContainsOperator : @(NSLikePredicateOperatorType),
+                                SCPredicateStringiContainsOperator : @(NSLikePredicateOperatorType)};
     
     return (NSPredicateOperatorType)[operators[operator] unsignedIntegerValue];
 }
+
+- (NSComparisonPredicateOptions)nspredicateOptionsForOperator:(NSString *)operator {
+    NSDictionary *operators = @{SCPredicateStringiStartsWithOperator: @(NSCaseInsensitivePredicateOption),
+                                SCPredicateStringiEndsWithOperator: @(NSCaseInsensitivePredicateOption),
+                                SCPredicateStringiEqualOperator : @(NSCaseInsensitivePredicateOption),
+                                SCPredicateStringiContainsOperator : @(NSCaseInsensitivePredicateOption)};
+    
+    NSNumber* option = operators[operator];
+    if(option == nil) {
+        return 0;
+    }
+    return [option unsignedIntegerValue];
+}
+
 @end

--- a/syncano-ios/SCPredicate+LocalStorage.m
+++ b/syncano-ios/SCPredicate+LocalStorage.m
@@ -27,6 +27,10 @@
     NSString* operator = [self operator];
     NSString* rightHand = [self rightHand];
     
+    if ([operator isEqualToString:SCPredicateIsOperator]) {
+        NSAssert(![operator isEqualToString:SCPredicateIsOperator], NSLocalizedString(@"SCPredicateIsOperator is not supported in local queries.", @""));
+    }
+    
     if([operator isEqualToString:SCPredicateStringContainsOperator] || [operator isEqualToString:SCPredicateStringiContainsOperator]) {
         rightHand = [NSString stringWithFormat:@"*%@*",rightHand];
     }


### PR DESCRIPTION
It doesn't support SCPredicateIsOperator because it would be useful only for saving Views to local storage. Unfortunately such action breaks relation - only related object id is saved, not the whole object. In such circumstances SCPredicateIsOperator support is useless.