### PR TITLE
[LIB-713] Added predicate for relations

### DIFF
--- a/syncano-ios/SCPredicate.h
+++ b/syncano-ios/SCPredicate.h
@@ -369,8 +369,12 @@ extern NSString *const SCPredicateNearOpeartor;
 + (SCPredicate *)whereKey:(NSString *)key isNearGeoPoint:(SCGeoPoint *)geopoint withinKilometers:(double)maxDistance;
 @end
 
+@interface SCPredicate (Reference)
++ (SCPredicate *)whereReferenceKey:(NSString *)referenceKey satisfiesPredicate:(id<SCPredicateProtocol>)predicate;
+@end
+
 @interface SCPredicate (Relation)
 + (SCPredicate *)whereRelationWithKey:(NSString *)relationKey contains:(NSArray<NSNumber *>*)objectIds;
-+ (SCPredicate *)whereRelationWithKey:(NSString *)relationKey conformsToPredicate:(SCPredicate *)predicate;
++ (SCPredicate *)whereRelationWithKey:(NSString *)relationKey satisfiesPredicate:(id<SCPredicateProtocol>)predicate;
 @end
 NS_ASSUME_NONNULL_END

--- a/syncano-ios/SCPredicate.h
+++ b/syncano-ios/SCPredicate.h
@@ -368,4 +368,9 @@ extern NSString *const SCPredicateNearOpeartor;
 + (SCPredicate *)whereKey:(NSString *)key isNearGeoPoint:(SCGeoPoint *)geopoint withinMiles:(double)maxDistance;
 + (SCPredicate *)whereKey:(NSString *)key isNearGeoPoint:(SCGeoPoint *)geopoint withinKilometers:(double)maxDistance;
 @end
+
+@interface SCPredicate (Relation)
++ (SCPredicate *)whereRelationWithKey:(NSString *)relationKey contains:(NSArray<NSNumber *>*)objectIds;
++ (SCPredicate *)whereRelationWithKey:(NSString *)relationKey conformsToPredicate:(SCPredicate *)predicate;
+@end
 NS_ASSUME_NONNULL_END

--- a/syncano-ios/SCPredicate.m
+++ b/syncano-ios/SCPredicate.m
@@ -17,6 +17,7 @@ NSString *const SCPredicateEqualOperator = @"_eq";
 NSString *const SCPredicateNotEqualOperator = @"_neq";
 NSString *const SCPredicateExistsOperator = @"_exists";
 NSString *const SCPredicateInOperator = @"_in";
+NSString *const SCPredicateContainsOperator = @"_contains";
 NSString *const SCPredicateStringStartsWithOperator = @"_startswith";
 NSString *const SCPredicateStringiStartsWithOperator = @"_istartswith";
 NSString *const SCPredicateStringEndsWithOperator = @"_endswith";
@@ -204,4 +205,13 @@ NSString *const SCPredicateNearOpeartor = @"_near";
     return [[SCPredicate alloc] initWithLeftHand:key operator:SCPredicateNearOpeartor rightHand:rightHand];
 }
 
+@end
+
+@implementation SCPredicate (Relation)
++ (SCPredicate *)whereRelationWithKey:(NSString *)relationKey contains:(NSArray<NSNumber *>*)objectIds {
+    return [[SCPredicate alloc] initWithLeftHand:relationKey operator:SCPredicateContainsOperator rightHand:objectIds];
+}
++ (SCPredicate *)whereRelationWithKey:(NSString *)relationKey conformsToPredicate:(SCPredicate *)predicate {
+    return [[SCPredicate alloc] initWithLeftHand:relationKey operator:SCPredicateIsOperator rightHand:[predicate rawPredicate]];
+}
 @end

--- a/syncano-ios/SCPredicate.m
+++ b/syncano-ios/SCPredicate.m
@@ -207,11 +207,17 @@ NSString *const SCPredicateNearOpeartor = @"_near";
 
 @end
 
+@implementation SCPredicate (Reference)
++ (SCPredicate *)whereReferenceKey:(NSString *)referenceKey satisfiesPredicate:(id<SCPredicateProtocol>)predicate {
+    return [SCPredicate whereKey:referenceKey satisfiesPredicate:predicate];
+}
+@end
+
 @implementation SCPredicate (Relation)
 + (SCPredicate *)whereRelationWithKey:(NSString *)relationKey contains:(NSArray<NSNumber *>*)objectIds {
     return [[SCPredicate alloc] initWithLeftHand:relationKey operator:SCPredicateContainsOperator rightHand:objectIds];
 }
-+ (SCPredicate *)whereRelationWithKey:(NSString *)relationKey conformsToPredicate:(SCPredicate *)predicate {
-    return [[SCPredicate alloc] initWithLeftHand:relationKey operator:SCPredicateIsOperator rightHand:[predicate rawPredicate]];
++ (SCPredicate *)whereRelationWithKey:(NSString *)relationKey satisfiesPredicate:(id<SCPredicateProtocol>)predicate {
+    return [SCPredicate whereKey:relationKey satisfiesPredicate:predicate];
 }
 @end


### PR DESCRIPTION
Usage:

**_contains**

```
SCPredicate *predicate = [SCPredicate whereRelationWithKey:@"books" contains:@[@4,@12]];
    [[BookStore please] giveMeDataObjectsWithPredicate:predicate parameters:nil completion:^(NSArray * _Nullable objects, NSError * _Nullable error) {
        
    }];
```

**_is**

```
    SCPredicate *numOfPagespredicate = [SCPredicate whereKey:@"numofpages" isEqualToNumber:@1233];
    SCPredicate *predicate = [SCPredicate whereRelationWithKey:@"books" conformsToPredicate:numOfPagespredicate];
    [[BookStore please] giveMeDataObjectsWithPredicate:predicate parameters:nil completion:^(NSArray * _Nullable objects, NSError * _Nullable error) {
        
    }];
```