### PR TITLE
Hotfix saving files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Syncano's iOS Library (syncano-ios) is available under the MIT license. See the 
 
 ## Change Log
 --
+* **4.2.2** - 2016-07-18
+    * Fix for saving files 
 * **4.2.1** - 2016-07-18
     * Added autoregister all SCDataObject subclasses while creating Syncano object
     * Added SCDevice delete methods

--- a/syncano-ios.podspec
+++ b/syncano-ios.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "syncano-ios"
-  s.version      = "4.2.1"
+  s.version      = "4.2.2"
   s.summary      = "Library for http://syncano.com API"
 
   s.homepage     = "http://www.syncano.com"

--- a/syncano-ios/SCAPIClient.h
+++ b/syncano-ios/SCAPIClient.h
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)DELETEWithPath:(NSString *)path params:(nullable NSDictionary *)params completion:(nullable SCAPICompletionBlock)completion;
 
 /**
- *  "Abstract" method to upload file method call added to queue
+ *  "Abstract" method to upload file method call added to queue with POST method
  *
  *  @param path         path to request endpoint
  *  @param propertyName name of a file variable name inside a class
@@ -105,6 +105,16 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param completion   completion block
  */
 - (void)POSTUploadWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData completion:(nullable SCAPICompletionBlock)completion;
+
+/**
+ *  "Abstract" method to upload file method call added to queue with PATCH method
+ *
+ *  @param path         path to request endpoint
+ *  @param propertyName name of a file variable name inside a class
+ *  @param fileData     NSData file representation
+ *  @param completion   completion block
+ */
+- (void)PATCHUploadWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData completion:(nullable SCAPICompletionBlock)completion;
 
 /**
  *  "Abstract" method to GET method call without queue

--- a/syncano-ios/SCAPIClient.m
+++ b/syncano-ios/SCAPIClient.m
@@ -147,7 +147,12 @@
 }
 
 - (void)POSTUploadWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData completion:(SCAPICompletionBlock)completion {
-    [self.requestQueue enqueueUploadRequestWithPath:path propertyName:propertyName fileData:fileData callback:completion];
+    [self.requestQueue enqueuePOSTUploadRequestWithPath:path propertyName:propertyName fileData:fileData callback:completion];
+    [self runQueue];
+}
+
+- (void)PATCHUploadWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData completion:(SCAPICompletionBlock)completion {
+    [self.requestQueue enqueuePATCHUploadRequestWithPath:path propertyName:propertyName fileData:fileData callback:completion];
     [self runQueue];
 }
 

--- a/syncano-ios/SCAPIClient.m
+++ b/syncano-ios/SCAPIClient.m
@@ -210,6 +210,7 @@
                 break;
             case SCRequestMethodPATCH:
                 [self patchUploadTaskWithPath:path propertyName:propertyName fileData:fileData completion:requestFinishedBlock];
+                break;
             default: {
                 NSError *error = [NSError errorWithDomain:SCRequestErrorDomain code:1001 userInfo:@{NSLocalizedFailureReasonErrorKey : @"Wrong request method used for file upload. Use PATCH or POST"}];
                 if (requestFinishedBlock) {
@@ -218,7 +219,6 @@
                 break;
             }
         }
-        [self patchUploadTaskWithPath:path propertyName:propertyName fileData:fileData completion:requestFinishedBlock];
     } else {
         switch (method) {
             case SCRequestMethodGET:

--- a/syncano-ios/SCFile.m
+++ b/syncano-ios/SCFile.m
@@ -61,7 +61,7 @@
 
 - (void)saveAsPropertyWithName:(NSString *)name ofDataObject:(SCDataObject *)dataObject usingAPIClient:(SCAPIClient *)apiClient withCompletion:(SCCompletionBlock)completion {
     if (self.needsToBeUploaded && self.data != nil) {
-        [apiClient POSTUploadWithPath:dataObject.path propertyName:name fileData:self.data completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
+        [apiClient PATCHUploadWithPath:dataObject.path propertyName:name fileData:self.data completion:^(NSURLSessionDataTask *task, id responseObject, NSError *error) {
             if (!error) {
                 self.needsToBeUploaded = NO;
             }

--- a/syncano-ios/SCRequestQueue.h
+++ b/syncano-ios/SCRequestQueue.h
@@ -81,14 +81,24 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enqueuePUTRequestWithPath:(NSString *)path params:(nullable NSDictionary *)params callback:(nullable SCAPICompletionBlock)callback;
 
 /**
- *  Enqueues upload request
+ *  Enqueues POST upload request
  *
  *  @param path         URI of the request
  *  @param propertyName property (variable) name of a file
  *  @param fileData     NSData representation of a file
  *  @param callback     callback block
  */
-- (void)enqueueUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(nullable SCAPICompletionBlock)callback;
+- (void)enqueuePOSTUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(nullable SCAPICompletionBlock)callback;
+
+/**
+ *  Enqueues PATCH upload request
+ *
+ *  @param path         URI of the request
+ *  @param propertyName property (variable) name of a file
+ *  @param fileData     NSData representation of a file
+ *  @param callback     callback block
+ */
+- (void)enqueuePATCHUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(nullable SCAPICompletionBlock)callback;
 
 /**
  *  Enqueues GET request and store it on disk
@@ -141,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)enqueuePUTRequestWithPath:(NSString *)path params:(nullable NSDictionary *)params callback:(nullable SCAPICompletionBlock)callback save:(BOOL)save;
 
 /**
- *  Enqueues upload request and store it on disk
+ *  Enqueues POST upload request and store it on disk
  *
  *  @param path         URI of the request
  *  @param propertyName property (variable) name of a file
@@ -149,7 +159,18 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param callback     callback block
  *  @param save         boolean which determines if this request should be stored on disk
  */
-- (void)enqueueUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(nullable SCAPICompletionBlock)callback save:(BOOL)save;
+- (void)enqueuePOSTUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(nullable SCAPICompletionBlock)callback save:(BOOL)save;
+
+/**
+ *  Enqueues PATCH upload request and store it on disk
+ *
+ *  @param path         URI of the request
+ *  @param propertyName property (variable) name of a file
+ *  @param fileData     NSData representation of a file
+ *  @param callback     callback block
+ *  @param save         boolean which determines if this request should be stored on disk
+ */
+- (void)enqueuePATCHUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(nullable SCAPICompletionBlock)callback save:(BOOL)save;
 
 /**
  *  Dequeues request from queue

--- a/syncano-ios/SCRequestQueue.m
+++ b/syncano-ios/SCRequestQueue.m
@@ -59,8 +59,11 @@
 - (void)enqueuePUTRequestWithPath:(NSString *)path params:(NSDictionary *)params callback:(SCAPICompletionBlock)callback {
     [self enqueuePUTRequestWithPath:path params:params callback:callback save:NO];
 }
-- (void)enqueueUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(SCAPICompletionBlock)callback {
-    [self enqueueUploadRequestWithPath:path propertyName:propertyName fileData:fileData callback:callback save:NO];
+- (void)enqueuePOSTUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(SCAPICompletionBlock)callback {
+    [self enqueuePOSTUploadRequestWithPath:path propertyName:propertyName fileData:fileData callback:callback save:NO];
+}
+- (void)enqueuePATCHUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(SCAPICompletionBlock)callback {
+    [self enqueuePATCHUploadRequestWithPath:path propertyName:propertyName fileData:fileData callback:callback save:NO];
 }
 
 - (void)enqueueGETRequestWithPath:(NSString *)path params:(NSDictionary *)params callback:(SCAPICompletionBlock)callback save:(BOOL)save {
@@ -83,9 +86,12 @@
     SCRequest *request = [SCRequest requestWithPath:path method:SCRequestMethodPUT params:params callback:callback save:save];
     [self enqueueRequest:request];
 }
-
-- (void)enqueueUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(SCAPICompletionBlock)callback save:(BOOL)save {
-    SCUploadRequest *request = [SCUploadRequest uploadRequestWithPath:path propertName:propertyName fileData:fileData callback:callback save:save];
+- (void)enqueuePOSTUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(SCAPICompletionBlock)callback save:(BOOL)save {
+    SCUploadRequest *request = [SCUploadRequest uploadRequestWithPath:path method:SCRequestMethodPOST propertName:propertyName fileData:fileData callback:callback save:save];
+    [self enqueueRequest:request];
+}
+- (void)enqueuePATCHUploadRequestWithPath:(NSString *)path propertyName:(NSString *)propertyName fileData:(NSData *)fileData callback:(SCAPICompletionBlock)callback save:(BOOL)save {
+    SCUploadRequest *request = [SCUploadRequest uploadRequestWithPath:path method:SCRequestMethodPATCH propertName:propertyName fileData:fileData callback:callback save:save];
     [self enqueueRequest:request];
 }
 

--- a/syncano-ios/SCUploadRequest.h
+++ b/syncano-ios/SCUploadRequest.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return SCUploadRequest instance
  */
-+ (SCUploadRequest *)uploadRequestWithPath:(NSString *)path propertName:(NSString *)propertyName fileData:(NSData *)fileData callback:(nullable SCAPICompletionBlock)callback save:(BOOL)save;
++ (SCUploadRequest *)uploadRequestWithPath:(NSString *)path method:(SCRequestMethod)method propertName:(NSString *)propertyName fileData:(NSData *)fileData callback:(nullable SCAPICompletionBlock)callback save:(BOOL)save;
 
 
 @end

--- a/syncano-ios/SCUploadRequest.m
+++ b/syncano-ios/SCUploadRequest.m
@@ -10,8 +10,8 @@
 
 @implementation SCUploadRequest
 
-- (instancetype)initWithPath:(NSString *)path propertName:(NSString *)propertyName fileData:(NSData *)fileData callback:(SCAPICompletionBlock)callback save:(BOOL)save {
-    self = [super initWithPath:path method:SCRequestMethodPATCH params:nil callback:callback save:save];
+- (instancetype)initWithPath:(NSString *)path method:(SCRequestMethod)method propertName:(NSString *)propertyName fileData:(NSData *)fileData callback:(SCAPICompletionBlock)callback save:(BOOL)save {
+    self = [super initWithPath:path method:method params:nil callback:callback save:save];
     if (self) {
         self.propertyName = propertyName;
         self.fileData = fileData;
@@ -19,8 +19,8 @@
     return self;
 }
 
-+ (SCUploadRequest *)uploadRequestWithPath:(NSString *)path propertName:(NSString *)propertyName fileData:(NSData *)fileData callback:(SCAPICompletionBlock)callback save:(BOOL)save {
-    SCUploadRequest *request = [[SCUploadRequest alloc] initWithPath:path propertName:propertyName fileData:fileData callback:callback save:save];
++ (SCUploadRequest *)uploadRequestWithPath:(NSString *)path method:(SCRequestMethod)method propertName:(NSString *)propertyName fileData:(NSData *)fileData callback:(nullable SCAPICompletionBlock)callback save:(BOOL)save {
+    SCUploadRequest *request = [[SCUploadRequest alloc] initWithPath:path method:method propertName:propertyName fileData:fileData callback:callback save:save];
     return request;
 }
 


### PR DESCRIPTION
Fixed saving files - it was sending two requests, break was missing, so callback for saving one file was called 3 times... causing crashes and exceptions.
Before calling POSTUpload was actually sending PATCH… Created separate
methods for PATCH and POST upload.